### PR TITLE
First Xcode detection when it's already installed

### DIFF
--- a/tools/gen_sdk_package.sh
+++ b/tools/gen_sdk_package.sh
@@ -26,7 +26,7 @@ else
   fi
 fi
 
-if [ ! -d "$XCODEDIR" ]; then
+if [ ! -d $XCODEDIR ]; then
   echo "cannot find Xcode (XCODEDIR=$XCODEDIR)"
   exit 1
 fi


### PR DESCRIPTION
`XCODEDIR` isn't properly detected when using installed Xcode
