### PR TITLE
Change std to lstd in Target::isCXX11orNewer()

### DIFF
--- a/wrapper/target.cpp
+++ b/wrapper/target.cpp
@@ -175,8 +175,8 @@ bool Target::isCXX11orNewer() const {
                                   "c++1y", "gnu++1y", "c++14", "gnu++14",
                                   "c++1z", "gnu++1z" };
 
-  for (auto std : STD) {
-    if (!strcmp(langstd, std))
+  for (auto lstd : STD) {
+    if (!strcmp(langstd, lstd))
       return true;
   }
 


### PR DESCRIPTION
Apparently `std` seems to be reserved, as the compilation fails when using this name:

```
target.cpp:178:17: error: unexpected ':' in nested name specifier; did you mean '::'?
  for (auto std : STD) {
                ^
                ::
target.cpp:178:19: error: definition or redeclaration of 'STD' not allowed inside a function
  for (auto std : STD) {
            ~~~~~ ^
target.cpp:178:19: error: no member named 'STD' in namespace 'std'
  for (auto std : STD) {
            ~~~~~ ^
target.cpp:178:19: error: declaration of variable 'STD' with type 'auto' requires an initializer
target.cpp:178:22: error: expected ';' in 'for' statement specifier
  for (auto std : STD) {
                     ^
target.cpp:178:22: error: expected ';' in 'for' statement specifier
target.cpp:179:26: error: unexpected namespace name 'std': expected expression
    if (!strcmp(langstd, std))
```
