### PR TITLE
Add a reference to multiarch/crossbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ You can build OSXCross with GCC this way:
 
 You will need gcc/g++/gcc-objc 4.7+.
 
+### PROJECTS USING OSXCROSS: ###
+
+* [multiarch/crossbuild](https://github.com/multiarch/crossbuild), various cross-compilers (systems:linux,osx,windows, archs:x86_64,i386,arm,ppc,mips) in Docker. OSXCross powers the Darwin builds.
+
 ### LICENSE: ####
   * scripts/wrapper: GPLv2
   * cctools/ld64: APSL 2.0


### PR DESCRIPTION
Hi,

This PR adds a reference to [multiarch/crossbuild](https://github.com/multiarch/crossbuild) in the README.md.
