### PR TITLE
Let osxcross-macports pick up noarch packages

### DIFF
--- a/tools/osxcross-macports
+++ b/tools/osxcross-macports
@@ -264,6 +264,9 @@ getPkgUrl()
   done
 
   local pkg=$(echo "$pkgs" | grep $OSXVERSION | grep $ARCH | uniq | tail -n1)
+  if [ -z "$pkg" ]; then
+    pkg=$(echo "$pkgs" | grep $OSXVERSION | grep "noarch" | uniq | tail -n1)
+  fi
 
   verboseMsg " selected: $pkg"
 


### PR DESCRIPTION
Some packages (such as the qt5 metapackage) are not architecture-specific - "noarch" versions should work on all architectures.