### PR TITLE
Add patch for ranlib bug not yet fixed in cctools 877.8

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -149,6 +149,7 @@ pushd .. &>/dev/null
 popd &>/dev/null
 patch -p0 < $PATCH_DIR/cctools-ld64-1.patch
 patch -p0 < $PATCH_DIR/cctools-ld64-2.patch
+patch -p0 < $PATCH_DIR/cctools-ld64-3.patch
 echo ""
 CONFFLAGS="--prefix=$TARGET_DIR --target=x86_64-apple-$TARGET "
 CONFFLAGS+="--disable-clang-as "

--- a/patches/cctools-ld64-3.patch
+++ b/patches/cctools-ld64-3.patch
@@ -1,0 +1,11 @@
+--- misc/libtool.c
++++ misc/libtool.c
+@@ -1526,7 +1526,7 @@ void)
+ 			for(k = 0; k < archs[j].nmembers; k++){
+ 			    if(archs[j].members[k].mh == NULL &&
+ #ifdef LTO_SUPPORT
+-			       archs[j].members[k].lto_contents == TRUE &&
++			       archs[j].members[k].lto_contents == FALSE &&
+ #endif /* LTO_SUPPORT */
+ 			       archs[j].members[k].mh64 == NULL){
+ 				error("library member: %s(%.*s) is not an "


### PR DESCRIPTION
One behavior of cctools' libtool when invoked as ranlib is rotating archives of universal object files (such as those created by `clang -arch i386 -arch x86_64 -c ...`) into universal files containing per-architecture archives each containing single-architecture objects. From Xcode 7 until Xcode 7.3, whose cctools/ld64 are not yet open source, there was a bug where this would fail if any of the individual objects were LLVM bitcode objects rather than natively compiled ones, and incorrectly succeed with nonsensical results if such an archive contained members that were not recognizable object files at all. The fix is straightforward and this commit adds a patch to apply it while we wait for newer cctools sources to be released.

(This might be a bit of a trivial obsessive pet peeve, but it's still a bug & one that I would in fact encounter in the wild while trying to make the toolchain do honest to god not-particularly-ridiculous things and we may as well apply the fix manually for the greater good as long as the officially fixed sources aren't available yet.)