### PR TITLE
skip fuse module check in ubuntu

### DIFF
--- a/tools/gen_sdk_package_darling_dmg.sh
+++ b/tools/gen_sdk_package_darling_dmg.sh
@@ -26,7 +26,13 @@ require fusermount
 
 set +e
 
-modinfo fuse &>/dev/null
+command -v lsb_release 2>&1 > /dev/null
+
+if [[ $? -eq 0 ]] && [[ -n `lsb_release -a 2>&1 | grep -i ubuntu` ]]; then
+    echo "Using ubuntu, skip fuse module check"
+else
+    modinfo fuse &>/dev/null
+fi
 
 if [ $? -ne 0 ]; then
   echo "required kernel module 'fuse' not loaded" 1>&2


### PR DESCRIPTION
I'm using Kubuntu 16.04 and it seems that fuse has been built into kernel. I can no more find the package `fuse-utils` in repository.

Not sure since when it's been in the kernel... but better to let users handle it?