### PR TITLE
Added functionality to have clang in a custom directory, and not in the PATH

### DIFF
--- a/wrapper/main.cpp
+++ b/wrapper/main.cpp
@@ -172,6 +172,11 @@ bool compilerpath(Target &target, const char *, const char *path, char **) {
   return true;
 }
 
+bool intrinsicpath(Target &target, const char *, const char *path, char **) {
+  target.intrinsicpath = path;
+  return true;
+}
+
 bool runprog(Target &target, const char *, const char *progname, char **cargs) {
   auto *prog = program::getprog(progname);
 
@@ -263,7 +268,13 @@ constexpr struct Opt {
   {"-icxx-isystem", checkincludepath, true, true},
   {"-cxx-isystem", checkincludepath, true, true},
   {"-I", checkincludepath, true, true},
-  {"-foc-compiler-path", compilerpath, true, false, "="} // sets a custom path for the compiler
+
+  // sets a custom path for the compiler
+  {"-foc-compiler-path", compilerpath, true, false, "="},
+
+  // specifies an additional directory to search when looking for clang's
+  // intrinsic paths
+  {"-foc-intrinsic-path", intrinsicpath, true, false, "="}
 };
 
 bool parse(int argc, char **argv, Target &target) {

--- a/wrapper/main.cpp
+++ b/wrapper/main.cpp
@@ -289,7 +289,14 @@ bool parse(int argc, char **argv, Target &target) {
     char *arg = argv[i];
 
     if (*arg != '-') {
-      target.args.push_back(arg);
+      // Check if the argument has spaces, we need to add back the quotes if
+      // that's the case
+      std::string argument = arg;
+      if (argument.find_first_of("\t\n ") != std::string::npos) {
+        argument = "\"" + argument + "\"";
+      }
+
+      target.args.push_back(argument);
       continue;
     }
 

--- a/wrapper/main.cpp
+++ b/wrapper/main.cpp
@@ -289,14 +289,7 @@ bool parse(int argc, char **argv, Target &target) {
     char *arg = argv[i];
 
     if (*arg != '-') {
-      // Check if the argument has spaces, we need to add back the quotes if
-      // that's the case
-      std::string argument = arg;
-      if (argument.find_first_of("\t\n ") != std::string::npos) {
-        argument = "\"" + argument + "\"";
-      }
-
-      target.args.push_back(argument);
+      target.args.push_back(arg);
       continue;
     }
 

--- a/wrapper/main.cpp
+++ b/wrapper/main.cpp
@@ -167,6 +167,11 @@ bool usegcclibstdcxx(Target &target, const char *, const char *, char **) {
   return true;
 }
 
+bool compilerpath(Target &target, const char *, const char *path, char **) {
+  target.compilerpath = path;
+  return true;
+}
+
 bool runprog(Target &target, const char *, const char *progname, char **cargs) {
   auto *prog = program::getprog(progname);
 
@@ -258,6 +263,7 @@ constexpr struct Opt {
   {"-icxx-isystem", checkincludepath, true, true},
   {"-cxx-isystem", checkincludepath, true, true},
   {"-I", checkincludepath, true, true},
+  {"-foc-compiler-path", compilerpath, true, false, "="} // sets a custom path for the compiler
 };
 
 bool parse(int argc, char **argv, Target &target) {

--- a/wrapper/target.cpp
+++ b/wrapper/target.cpp
@@ -409,6 +409,10 @@ do {                                                                           \
   TRYDIR2("/../include/clang");
   TRYDIR2("/usr/include/clang");
 
+  if (!intrinsicpath.empty()) {
+    TRYDIR2(intrinsicpath);
+  }
+
   return false;
 #undef TRYDIR
 #undef TRYDIR2

--- a/wrapper/target.cpp
+++ b/wrapper/target.cpp
@@ -289,10 +289,15 @@ void Target::setCompilerPath() {
     compilerexecname += "-";
     compilerexecname += compilername;
   } else {
-    if (!realPath(compilername.c_str(), compilerpath, ignoreCCACHE))
-      compilerpath = compilername;
+    if (!compilerpath.empty()) {
+      compilerpath += "/";
+      compilerpath += compilername;
+    } else {
+      if (!realPath(compilername.c_str(), compilerpath, ignoreCCACHE))
+        compilerpath = compilername;
 
-    compilerexecname += compilername;
+      compilerexecname += compilername;
+    }
   }
 }
 

--- a/wrapper/target.h
+++ b/wrapper/target.h
@@ -149,6 +149,7 @@ struct Target {
   string_vector args;
   const char *language;
   char execpath[PATH_MAX + 1];
+  std::string intrinsicpath;
 };
 
 } // namespace target


### PR DESCRIPTION
In some environments you can't rely on the compiler's location being on the path, or you want a specific version of clang to be used.

With the `-foc-compiler-path=<location>` command line switch you can specify the compiler's path and osxcross will not attempt to look in the PATH for it.