### PR TITLE
 Fix compilation issue in `darling-dmg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### WHAT IS THE GOAL OF OSXCROSS? ###
 
 The goal of OSXCross is to provide a well working OS X cross toolchain for
-Linux, *BSD, and Cygwin.
+Linux, \*BSD, and Cygwin.
 
 ### HOW DOES IT WORK? ###
 

--- a/tools/gen_sdk_package_darling_dmg.sh
+++ b/tools/gen_sdk_package_darling_dmg.sh
@@ -57,7 +57,7 @@ if [ ! -f $TARGET_DIR/SDK/tools/bin/darling-dmg ]; then
   rm -f have_darling_dmg
 fi
 
-DARLING_DMG_REV="b7ce87bfe59c2ed758165c8650402f6d4c84d184"
+DARLING_DMG_REV="4e3a2ede86d4e3c63bcc97d7280dd8613d70cde2"
 
 if [ ! -f "have_darling_dmg_$DARLING_DMG_REV" ]; then
 


### PR DESCRIPTION
This pulls in the https://github.com/darlinghq/darling-dmg/pull/41 fix
for compilation with newer GCC.

The error message this fixes is
```
osxcross/build/darling-dmg/src/main-fuse.cpp:137:28: error: no member named 'function' in namespace 'std'
int handle_exceptions(std::function<int()> func)
                      ~~~~~^
osxcross/build/darling-dmg/src/main-fuse.cpp:137:44: error: use of undeclared identifier 'func'
int handle_exceptions(std::function<int()> func)
                                           ^
osxcross/build/darling-dmg/src/main-fuse.cpp:137:49: error: expected ';' after top level declarator
int handle_exceptions(std::function<int()> func)
                                                ^
                                                ;
3 errors generated.
```
