### PR TITLE
Feature: get_dependencies for Arch linux users

### DIFF
--- a/tools/get_dependencies.sh
+++ b/tools/get_dependencies.sh
@@ -4,7 +4,7 @@
 # this assumes you are running as root or are using sudo
 #
 
-USER="$(env | grep 'USER' | cut -d '=' -f2 | head -1)"
+USER="$(stat --format=%U .)"
 
 get_fedora_deps()
 {

--- a/tools/get_dependencies.sh
+++ b/tools/get_dependencies.sh
@@ -4,7 +4,7 @@
 # this assumes you are running as root or are using sudo
 #
 
-USER="$(cat /etc/passwd | grep '/home' | cut -d: -f1 | head -1)"
+USER="$(env | grep 'USER' | cut -d '=' -f2 | head -1)"
 
 get_fedora_deps()
 {

--- a/tools/get_dependencies.sh
+++ b/tools/get_dependencies.sh
@@ -44,6 +44,11 @@ get_debian_deps()
   libssl-dev bash patch make  tar xz-utils bzip2 gzip sed cpio libbz2-dev
 }
 
+get_arch_deps()
+{
+ pacman -S clang llvm libxml2 openssl bash patch make tar bzip2 gzip sed cpio xz
+}
+
 unknown()
 {
  echo "Unknown system type. Please get dependencies by hand "
@@ -67,6 +72,8 @@ if [ -e /etc/issue ]; then
   get_fedora_deps
  elif [ "`grep -i mageia /etc/issue`" ]; then
   get_mageia_deps
+ elif [ "`grep -i arch /etc/issue`" ]; then
+  get_arch_deps
  else
   unknown
  fi

--- a/tools/get_dependencies.sh
+++ b/tools/get_dependencies.sh
@@ -4,6 +4,8 @@
 # this assumes you are running as root or are using sudo
 #
 
+USER="$(cat /etc/passwd | grep '/home' | cut -d: -f1 | head -1)"
+
 get_fedora_deps()
 {
  yum install clang llvm-devel libxml2-devel libuuid-devel openssl-devel \
@@ -73,7 +75,10 @@ if [ -e /etc/issue ]; then
  elif [ "`grep -i mageia /etc/issue`" ]; then
   get_mageia_deps
  elif [ "`grep -i arch /etc/issue`" ]; then
+  echo "Running pacman to install dependencies..."
   get_arch_deps
+  echo "Downloading and Installing uuid..."
+  sudo -u $USER -- sh -c 'git clone https://aur.archlinux.org/uuid.git /tmp/uuid; pushd /tmp/uuid; makepkg -srci; popd; rm -rf /tmp/uuid'
  else
   unknown
  fi


### PR DESCRIPTION
This script handles the fact that uuid is not available on Arch Linux package manager (pacman). It is instead downloaded and built from AUR using makepkg.

A possible limitation would be that if the target machine has multiple users, this line might not get the one you want... In that case, maybe you could enter the user you want in the variable definition.

Replace :
 USER="$(cat /etc/passwd | grep '/home' | cut -d: -f1 | head -1)" 
By:
 USER="username"