### PR TITLE
gen_sdk_package_pbzx.sh can handle relative path to Xcode

### DIFF
--- a/tools/gen_sdk_package_pbzx.sh
+++ b/tools/gen_sdk_package_pbzx.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+xcode=`readlink -e $1` # make absolute path name
+
 pushd "${0%/*}/.." &>/dev/null
 source tools/tools.sh
 
@@ -39,7 +41,7 @@ pushd $TMP_DIR &>/dev/null
 echo "Extracting $1 (this may take several minutes) ..."
 
 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TARGET_DIR/lib \
-  verbose_cmd "$TARGET_DIR/bin/xar -xf $1 -C $TMP_DIR"
+  verbose_cmd "$TARGET_DIR/bin/xar -xf ${xcode} -C $TMP_DIR"
 
 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TARGET_DIR/lib \
   verbose_cmd "$TARGET_DIR/SDK/tools/bin/pbzx -n Content | cpio -i"


### PR DESCRIPTION
gen_sdk_package_pbzx.sh did not work with relative path to Xcode. The error message does not give any clue on what's going on. In fact, the Xcode is unzipped in a temporary directory from which a relative path does not work.
This PR retrieves the absolute path to Xcode before going in the temporary directory so that it is possible to use relative paths.