### PR TITLE
Adding `--host` to build_gcc

### DIFF
--- a/build_gcc.sh
+++ b/build_gcc.sh
@@ -132,6 +132,7 @@ else
 fi
 
 ../configure \
+  --host=x86_64-apple-$OSXCROSS_TARGET \
   --target=x86_64-apple-$OSXCROSS_TARGET \
   --with-sysroot=$OSXCROSS_SDK \
   --disable-nls \


### PR DESCRIPTION
Running `build_gcc.sh` on debian fails and complains that `--host` needs to be added when cross compiling.
This PR adds the `--host` flag