### PR TITLE
Tell wget explicitly not to create directories

### DIFF
--- a/build_gcc.sh
+++ b/build_gcc.sh
@@ -45,9 +45,9 @@ if [ ! -f "have_gcc_${GCC_VERSION}_${TARGET}" ]; then
 
 pushd $TARBALL_DIR &>/dev/null
 if [[ $GCC_VERSION != *-* ]]; then
-  wget -c "$GCC_MIRROR/releases/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz"
+  wget -nd -c "$GCC_MIRROR/releases/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz"
 else
-  wget -c "$GCC_MIRROR/snapshots/$GCC_VERSION/gcc-$GCC_VERSION.tar.xz"
+  wget -nd -c "$GCC_MIRROR/snapshots/$GCC_VERSION/gcc-$GCC_VERSION.tar.xz"
 fi
 popd &>/dev/null
 


### PR DESCRIPTION
Somehow I never issued a pull - this is just a single fix for people who have customized wgetrc to mirror remote directories, but the build script assumes that downloads are in current directory.