### PR TITLE
FIX osxcross_conf.sh assumes default install dir

### DIFF
--- a/tools/osxcross_conf.sh
+++ b/tools/osxcross_conf.sh
@@ -2,7 +2,7 @@
 
 pushd "${0%/*}" &>/dev/null
 
-OSXCROSS_CONF="../target/bin/osxcross-conf"
+OSXCROSS_CONF="$TARGET_DIR/bin/osxcross-conf"
 [ -f $OSXCROSS_CONF ] || { OSXCROSS_CONF=$(which osxcross-conf 2>/dev/null) || exit 1; }
 
 $OSXCROSS_CONF || exit 1


### PR DESCRIPTION
osxcross_conf.sh assumes default install dir instead of TARGET_DIR
>replace
OSXCROSS_CONF="../target/bin/osxcross-conf"
>with
OSXCROSS_CONF="$TARGET_DIR/bin/osxcross-conf"