### PR TITLE
Fix building on CentOS 7.x

### DIFF
--- a/wrapper/Makefile
+++ b/wrapper/Makefile
@@ -9,7 +9,7 @@ LINKER_VERSION ?= 134.9
 LIBLTO_PATH ?=
 ADDITIONAL_CXXFLAGS ?=
 
-override CXXFLAGS=-std=c++1y -Wall -Wextra -pedantic
+override CXXFLAGS=-std=c++0x -Wall -Wextra
 override CXXFLAGS+=-Wno-missing-field-initializers
 override CXXFLAGS+=-I. -O$(OPTIMIZE)
 

--- a/wrapper/programs/osxcross-conf.cpp
+++ b/wrapper/programs/osxcross-conf.cpp
@@ -27,6 +27,12 @@ using namespace target;
 namespace program {
 namespace osxcross {
 
+template<typename A>
+
+void print(const char *var, const A &val) {
+  std::cout << "export OSXCROSS_" << var << "=" << val << std::endl;
+};
+
 int conf(Target &target) {
   std::string SDKPath;
   OSVersion OSXVersionMin = getDefaultMinTarget();
@@ -46,10 +52,6 @@ int conf(Target &target) {
 
   if (!ltopath)
     ltopath = "";
-
-  auto print = [](const char *var, const auto &val) {
-    std::cout << "export OSXCROSS_" << var << "=" << val << std::endl;
-  };
 
   print("VERSION", getOSXCrossVersion());
   print("OSX_VERSION_MIN", OSXVersionMin.shortStr());


### PR DESCRIPTION
With C++14 the following error happens on CentOS 7.x:
```
$ clang++ -std=c++1y -Wall -Wextra -pedantic -Wno-missing-field-initializers \
          -I. -O2 -DOSXCROSS_VERSION="\"1.2\"" -DOSXCROSS_TARGET="\"darwin14\"" \
          -DOSXCROSS_OSX_VERSION_MIN="\"10.6\"" -DOSXCROSS_LINKER_VERSION="\"530\"" \
          -DOSXCROSS_LIBLTO_PATH="\"/usr/lib64/llvm\"" \
          -DOSXCROSS_BUILD_DIR="\"/osxcross/build\""  -isystem quirks/include \
          -c -o target.o target.cpp
In file included from target.cpp:24:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/iostream:39:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/ostream:38:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/ios:42:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/bits/ios_base.h:41:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/bits/locale_classes.h:40:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/string:52:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/bits/basic_string.h:2815:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/ext/string_conversions.h:43:
/usr/bin/../lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/cstdio:120:11: error: no member named 'gets' in the global namespace
  using ::gets;
        ~~^
1 error generated.
```

That's a known issue with older C++ headers, see https://bugs.llvm.org/show_bug.cgi?id=30277

With C++11 we then get another problem:
```
$ clang++ -std=c++0x -Wall -Wextra -pedantic -Wno-missing-field-initializers \
          -I. -O2 -DOSXCROSS_VERSION="\"1.2\"" -DOSXCROSS_TARGET="\"darwin14\"" \
          -DOSXCROSS_OSX_VERSION_MIN="\"10.6\"" -DOSXCROSS_LINKER_VERSION="\"530\"" \
          -DOSXCROSS_LIBLTO_PATH="\"/usr/lib64/llvm\"" \
          -DOSXCROSS_BUILD_DIR="\"/osxcross/build\""  -isystem quirks/include \
          -c -o programs/osxcross-conf.o programs/osxcross-conf.cpp

programs/osxcross-conf.cpp:50:49: error: 'auto' not allowed in lambda parameter
  static auto print = [](const char *var, const auto &val) {
                                                ^~~~
programs/osxcross-conf.cpp:50:55: warning: unused parameter 'val' [-Wunused-parameter]
  static auto print = [](const char *var, const auto &val) {
                                                      ^
programs/osxcross-conf.cpp:54:3: error: no matching function for call to object of type '<lambda at programs/osxcross-conf.cpp:50:23>'
  print("VERSION", getOSXCrossVersion());
```

That last issue requires a move from a lambda to more ugly template solution. But in the end we get all built!

Well and also https://github.com/tpoechtrager/cctools-port/commit/c334553cc4b9fcddb00a7af11054eac28ca38949 is needed to get everything built smoothly.