### PR TITLE
Use official GNU download area

### DIFF
--- a/build_gcc.sh
+++ b/build_gcc.sh
@@ -28,7 +28,9 @@ if [ $(osxcross-cmp $OSX_VERSION_MIN '<=' 10.5) -eq 1 ]; then
 fi
 
 # GCC mirror
-GCC_MIRROR="https://mirror.koddos.net/gcc"
+# Official GNU "ftp" doesn't have GCC snapshots
+GCC_MIRROR="https://ftp.gnu.org/pub/gnu/gcc"
+GCC_MIRROR_WITH_SNAPSHOTS="https://mirror.koddos.net/gcc"
 
 pushd $BUILD_DIR &>/dev/null
 
@@ -43,9 +45,9 @@ if [ ! -f "have_gcc_${GCC_VERSION}_${TARGET}" ]; then
 
 pushd $TARBALL_DIR &>/dev/null
 if [[ $GCC_VERSION != *-* ]]; then
-  download "$GCC_MIRROR/releases/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz"
+  download "$GCC_MIRROR/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz"
 else
-  download "$GCC_MIRROR/snapshots/$GCC_VERSION/gcc-$GCC_VERSION.tar.xz"
+  download "$GCC_MIRROR_WITH_SNAPSHOTS/snapshots/$GCC_VERSION/gcc-$GCC_VERSION.tar.xz"
 fi
 popd &>/dev/null
 


### PR DESCRIPTION
There're quite a few mirrors where GNU software might be found. Though there're some problems with them:
 1. There's no guarantee any random mirror will be still up tomorrow
 2. For mere mortal it's not clear how credible if https://xxx-yyy-zzz.org in a sense that either tarball with sources might be corrupted
    unintentionally or even with some bad intentions.
    One solution here might be calculation of checksum but still as long as the main "FTP" storage of GNU project is up there's     not much sense in using a _hard-coded_ mirror.

Unfortunately snapshots of GCC are not hosted at https://ftp.gnu.org/, so keeping https://mirror.koddos.net for now.