### PR TITLE
build_clang.sh: Allow unmanned instllation

### DIFF
--- a/build_clang.sh
+++ b/build_clang.sh
@@ -130,12 +130,21 @@ else
   fi
 fi
 
-echo ""
-echo "Done!"
-echo ""
-echo -n "cd into '$PWD/$stage' and type 'make install' to install "
-echo "clang/llvm to '$INSTALLPREFIX'"
-echo ""
+if [ -z "$ENABLE_CLANG_INSTALL" ]; then
+  echo ""
+  echo "Done!"
+  echo ""
+  echo -n "cd into '$PWD/$stage' and type 'make install' to install "
+  echo "clang/llvm to '$INSTALLPREFIX'"
+  echo ""
+else
+  pushd $stage &>/dev/null
+  $MAKE install -j $JOBS VERBOSE=1
+  popd &>/dev/null
+  echo ""
+  echo "Done!"
+  echo ""
+fi
 
 popd &>/dev/null # llvm
 popd &>/dev/null


### PR DESCRIPTION
To get a completely env independent setup we may want to install Clang/LLVM to the target folder as well. So let's allow user to do it in a scripted way just adding `ENABLE_CLANG_INSTALL=1` for execution string.