### PR TITLE
tools.sh: Workaround hardcoded paths

### DIFF
--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -50,6 +50,14 @@ if [[ $PLATFORM == CYGWIN* ]]; then
   exit 1
 fi
 
+if [[ $PLATFORM == Darwin ]]; then
+  echo $PATH
+  CFLAGS_OPENSSL="$(pkg-config --cflags openssl)"
+  LDFLAGS_OPENSSL="$(pkg-config --libs-only-L openssl)"
+  export C_INCLUDE_PATH=${CFLAGS_OPENSSL:2}
+  export CPLUS_INCLUDE_PATH=${CFLAGS_OPENSSL:2}
+  export LIBRARY_PATH=${LDFLAGS_OPENSSL:2}
+fi
 
 function require()
 {


### PR DESCRIPTION
As OpenSSL is expected to be in a standard UNIX location but that's not always the case on macOS, this works around the issue regardless of package manager used as long as pkg-config is installed into $PATH

Macports default prefix is /opt/local
Homebrew on M1 uses /opt/homebrew


I'm sure there's a better way to handle this but if `pkg-config` is listed as a requirement this solves finding the dependencies without patches sources like xar.