### PR TITLE
verify_sdk_version: exit with code 1 if the SDK is not found

### DIFF
--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -179,7 +179,7 @@ function verify_sdk_version()
   done
   if [ ! $sdk ] ; then
     echo cant find SDK for OSX $sdkv in tarballs. exiting
-    exit
+    exit 1
   fi
 }
 


### PR DESCRIPTION
This PR updates the exit code for `verify_sdk_version` to `1` function if the SDK is not found.
This should help to stop the build in automatic scripts when the `SDK_VERSION` env variable is set to a invalid value.