### PR TITLE
compiler_rt: Build arm64 arch when targeting SDK 11.0+

### DIFF
--- a/build_compiler_rt.sh
+++ b/build_compiler_rt.sh
@@ -69,6 +69,11 @@ then
   exit 1
 fi
 
+export OSX_ARCHS="x86_64;x86_64h"
+if [ $(osxcross-cmp $SDK_VERSION ">=" 11.0) -eq 1 ]; then
+  export OSX_ARCHS="$OSX_ARCHS;arm64"
+fi
+
 HAVE_OS_LOCK=0
 
 if echo "#include <os/lock.h>" | xcrun clang -E - &>/dev/null; then
@@ -132,6 +137,8 @@ if [ $f_res -eq 1 ]; then
     pushd build &>/dev/null
 
     CC=$(xcrun -f clang) CXX=$(xcrun -f clang++) $CMAKE .. \
+      -DDARWIN_osx_ARCHS="$OSX_ARCHS" \
+      -DDARWIN_osx_BUILTIN_ARCHS="$OSX_ARCHS" \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_SYSTEM_NAME=Darwin \
       -DCMAKE_LIPO=$(xcrun -f lipo) \


### PR DESCRIPTION
Fixes #258.

Might be worth adding support for `arm64e` too but I don't know how to check if clang is Apple Clang (which seems to be the requirement as per https://github.com/tpoechtrager/osxcross#what-is-the-goal-of-osxcross).

Thanks to @etrinh and @ancwrd1 for figuring out the needed flag.

Worth noting that while testing this, I had one occurrence where the cmake build failed because it tried to recreate a symlink which existed already... but then I couldn't reproduce the issue anymore on two new attempts (each time starting from a clean git repo).