### PR TITLE
Update tarball download location to Github

### DIFF
--- a/build_clang.sh
+++ b/build_clang.sh
@@ -34,19 +34,22 @@ CLANG_PKG=""
 function set_package_link()
 {
   pushd $BUILD_DIR &>/dev/null
-  download https://releases.llvm.org/download.html &>/dev/null
-  if [[ $(file download.html) == *gzip* ]]; then
-    mv download.html download.html.gz
+
+  DOWNLOAD_PAGE=llvmorg-$CLANG_VERSION
+  download https://github.com/llvm/llvm-project/releases/tag/$DOWNLOAD_PAGE &>/dev/null
+
+  if [[ $(file $DOWNLOAD_PAGE) == *gzip* ]]; then
+    mv $DOWNLOAD_PAGE $DOWNLOAD_PAGE.gz
     require gzip
-    gzip -d download.html.gz
+    gzip -d $DOWNLOAD_PAGE.gz
   fi
-  links=$(cat download.html | grep -Po '(?<=href=")[^"]*' | grep -v "\.sig")
-  rm -f download.html
+  links=$(cat $DOWNLOAD_PAGE | grep -Po '(?<=href=")[^"]*' | grep -v "\.sig")
+  rm -f $DOWNLOAD_PAGE
   LLVM_PKG=$(echo "$links" | grep "llvm-$CLANG_VERSION.src" | head -n 1 || true)
   CLANG_PKG=$(echo "$links" | grep -E "(clang|cfe)-$CLANG_VERSION.src" | head -n 1 || true)
   if [ -n "$LLVM_PKG" ] && [[ $LLVM_PKG != https* ]]; then
-    LLVM_PKG="https://releases.llvm.org/$LLVM_PKG"
-    CLANG_PKG="https://releases.llvm.org/$CLANG_PKG"
+    LLVM_PKG="https://github.com/$LLVM_PKG"
+    CLANG_PKG="https://github.com/$CLANG_PKG"
   fi
   popd &>/dev/null
 }


### PR DESCRIPTION
Update tarball download location to Github to accommodate new download site format (introduced in version 11.0.1, but works for all versions).

Fixes #303. (see issue for further description)