### PR TITLE
Fix for compiler-rt 13.x build

### DIFF
--- a/build_compiler_rt.sh
+++ b/build_compiler_rt.sh
@@ -127,6 +127,9 @@ if [ $f_res -eq 1 ]; then
     $SED -i 's/${CMAKE_COMMAND} -E ${COMPILER_RT_LINK_OR_COPY}/ln -sf/g' \
       lib/builtins/CMakeLists.txt
 
+    $SED -i 's/list(APPEND ORC_CFLAGS -I${DIR})//g' \
+      lib/orc/CMakeLists.txt
+
     if [ $HAVE_OS_LOCK -eq 0 ]; then
       $SED -i "s/COMPILER_RT_HAS_TSAN TRUE/COMPILER_RT_HAS_TSAN FALSE/g" \
         cmake/config-ix.cmake


### PR DESCRIPTION
This PR fixes an issue with compiler-rt 13.x by disabling standard LLVM include dirs for lib/orc project.
Closes #308.
