### PR TITLE
Fix cmake wrapper breaking cmake build options

### DIFF
--- a/tools/osxcross-cmake
+++ b/tools/osxcross-cmake
@@ -12,5 +12,6 @@ fi
 
 eval "`$dir/$host-osxcross-conf`"
 export OSXCROSS_HOST="$host"
+export CMAKE_TOOLCHAIN_FILE="$OSXCROSS_TARGET_DIR"/toolchain.cmake
 
-exec cmake -DCMAKE_TOOLCHAIN_FILE="$OSXCROSS_TARGET_DIR"/toolchain.cmake "$@"
+exec cmake "$@"


### PR DESCRIPTION
Since cmake 3.20, "-D" prevents any build options (--build, --target, -j,
etc) from working. It will abort with an "unrecognized argument" error.

Fix the issue by passing the toolchain file as an env variable to cmake,
not with -D.