### PR TITLE
Make sure $BUILD_DIR exists before building compiler-rt

### DIFF
--- a/build_compiler_rt.sh
+++ b/build_compiler_rt.sh
@@ -78,6 +78,8 @@ fi
 
 export OSXCROSS_NO_10_5_DEPRECATION_WARNING=1
 
+mkdir -p $BUILD_DIR
+
 pushd $BUILD_DIR &>/dev/null
 
 get_sources https://github.com/llvm/llvm-project.git $BRANCH "compiler-rt"


### PR DESCRIPTION
This tiny fix resolves the issue when build_compiler_rt.sh silently fails without any messages whatsoever if the `build` directory is cleaned up.
