### PR TITLE
Add support for aarch64 builds

### DIFF
--- a/build_binutils.sh
+++ b/build_binutils.sh
@@ -52,8 +52,8 @@ function build_and_install()
     pushd build &>/dev/null
 
     ../configure \
-      --target=x86_64-apple-$TARGET \
-      --program-prefix=x86_64-apple-$TARGET- \
+      --target=${HOST_ARCH}-apple-$TARGET \
+      --program-prefix=${HOST_ARCH}-apple-$TARGET- \
       --prefix=$TARGET_DIR/binutils \
       --disable-nls \
       --disable-werror

--- a/build_gcc.sh
+++ b/build_gcc.sh
@@ -118,8 +118,8 @@ fi
 EXTRACONFFLAGS=""
 
 if [ "$PLATFORM" != "Darwin" ]; then
-  EXTRACONFFLAGS+="--with-ld=$TARGET_DIR/bin/x86_64-apple-$TARGET-ld "
-  EXTRACONFFLAGS+="--with-as=$TARGET_DIR/bin/x86_64-apple-$TARGET-as "
+  EXTRACONFFLAGS+="--with-ld=$TARGET_DIR/bin/${HOST_ARCH}-apple-$TARGET-ld "
+  EXTRACONFFLAGS+="--with-as=$TARGET_DIR/bin/${HOST_ARCH}-apple-$TARGET-as "
 fi
 
 LANGS="c,c++,objc,obj-c++"
@@ -135,7 +135,7 @@ else
 fi
 
 ../configure \
-  --target=x86_64-apple-$TARGET \
+  --target=${HOST_ARCH}-apple-$TARGET \
   --with-sysroot=$SDK \
   --disable-nls \
   --enable-languages=$LANGS \
@@ -152,7 +152,7 @@ $MAKE install
 
 GCC_VERSION=`echo $GCC_VERSION | tr '-' ' ' |  awk '{print $1}'`
 
-pushd $TARGET_DIR/x86_64-apple-$TARGET/include &>/dev/null
+pushd $TARGET_DIR/${HOST_ARCH}-apple-$TARGET/include &>/dev/null
 pushd c++/${GCC_VERSION}* &>/dev/null
 
 cat $PATCH_DIR/libstdcxx.patch | \
@@ -177,17 +177,17 @@ source tools/tools.sh
 pushd $TARGET_DIR/bin &>/dev/null
 
 if [ ! -f i386-apple-$TARGET-base-gcc ]; then
-  mv x86_64-apple-$TARGET-gcc \
-    x86_64-apple-$TARGET-base-gcc
+  mv ${HOST_ARCH}-apple-$TARGET-gcc \
+    ${HOST_ARCH}-apple-$TARGET-base-gcc
 
-  mv x86_64-apple-$TARGET-g++ \
-    x86_64-apple-$TARGET-base-g++
+  mv ${HOST_ARCH}-apple-$TARGET-g++ \
+    ${HOST_ARCH}-apple-$TARGET-base-g++
 
   if [ $(osxcross-cmp $SDK_VERSION "<=" 10.13) -eq 1 ]; then
-    create_symlink x86_64-apple-$TARGET-base-gcc \
+    create_symlink ${HOST_ARCH}-apple-$TARGET-base-gcc \
                    i386-apple-$TARGET-base-gcc
 
-    create_symlink x86_64-apple-$TARGET-base-g++ \
+    create_symlink ${HOST_ARCH}-apple-$TARGET-base-g++ \
                    i386-apple-$TARGET-base-g++
   fi
 fi
@@ -218,5 +218,5 @@ echo ""
 echo "Example 1: CC=o32-gcc ./configure --host=i386-apple-$TARGET"
 echo "Example 2: CC=i386-apple-$TARGET-gcc ./configure --host=i386-apple-$TARGET"
 echo "Example 3: o64-gcc -Wall test.c -o test"
-echo "Example 4: x86_64-apple-$TARGET-strip -x test"
+echo "Example 4: ${HOST_ARCH}-apple-$TARGET-strip -x test"
 echo ""

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -36,6 +36,7 @@ function set_path_vars()
     export PATCH_DIR=$PWD/patches
     export SDK_DIR=$TARGET_DIR/SDK
   fi
+  export HOST_ARCH="${HOST_ARCH:-$(uname -m)}"
 }
 
 set_path_vars

--- a/wrapper/build_wrapper.sh
+++ b/wrapper/build_wrapper.sh
@@ -117,7 +117,7 @@ function create_wrapper_link
 
 [ -z "$TARGETCOMPILER" ] && TARGETCOMPILER=clang
 
-TARGETTRIPLE=x86_64-apple-${TARGET}
+TARGETTRIPLE="${HOST_ARCH}-apple-${TARGET}"
 
 FLAGS=""
 
@@ -201,6 +201,7 @@ if [ "$PLATFORM" != "Darwin" ]; then
     # Just create target symlinks.
 
     verbose_cmd create_symlink $(which dsymutil) x86_64-apple-$TARGET-dsymutil
+    verbose_cmd create_symlink $(which dsymutil) aarch64-apple-$TARGET-dsymutil
 
     if [ $I386_SUPPORTED -eq 1 ]; then
       verbose_cmd create_symlink $(which dsymutil) i386-apple-$TARGET-dsymutil


### PR DESCRIPTION
This PR adds support for aarch64 builds to osxcross. 

So far osxcross only worked on x86_64 hosts, with this changes osxcross will also work on aarch64 (ARM 64 bit) hosts. This is necessary to support for example cross compiling from aarch64 based Linux hosts.