### PR TITLE
gen_sdk_package_tools_dmg: extract packages with not standard name

### DIFF
--- a/tools/gen_sdk_package_tools_dmg.sh
+++ b/tools/gen_sdk_package_tools_dmg.sh
@@ -76,15 +76,16 @@ pushd $TMP_DIR &>/dev/null
 
 echo ""
 echo "Unpacking $XCODE_TOOLS_DMG ..."
-XCODE_TOOLS_PKG="Command Line Developer Tools/Command Line Tools.pkg"
+XCODE_TOOLS_PKG="Command Line Developer Tools/Command Line Tools*.pkg"
+XCODE_TOOLS_PKG_TMP="Command Line Tools.pkg"
 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TARGET_DIR/lib \
-  verbose_cmd "$TARGET_DIR_SDK_TOOLS/bin/7z x \"$XCODE_TOOLS_DMG\"  \"$XCODE_TOOLS_PKG\""
+  verbose_cmd "$TARGET_DIR_SDK_TOOLS/bin/7z e -so \"$XCODE_TOOLS_DMG\"  \"$XCODE_TOOLS_PKG\" > \"$XCODE_TOOLS_PKG_TMP\""
 
 echo ""
-echo "Unpacking $XCODE_TOOLS_PKG ..."
+echo "Unpacking $XCODE_TOOLS_PKG_TMP ..."
 mkdir "$TMP_DIR/pkg_data"
 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TARGET_DIR/lib \
-  verbose_cmd "$TARGET_DIR/bin/xar -xf \"$XCODE_TOOLS_PKG\" -C $TMP_DIR/pkg_data"
+  verbose_cmd "$TARGET_DIR/bin/xar -xf \"$XCODE_TOOLS_PKG_TMP\" -C $TMP_DIR/pkg_data"
 
 echo ""
 echo "Processing packages ..."


### PR DESCRIPTION
This PR allows to extract the Command Line Tools pkg with a not standard name from the .dmg.
For example `Command_Line_Tools_macOS_10.11_for_Xcode_8.2.dmg` contains `Command Line Tools (macOS El Capitan version 10.11).pkg` and the `Command_Line_Tools_OS_X_10.11_for_Xcode_7.3.dmg` contains `Command Line Tools (OS X 10.11).pkg` instead of `Command Line Tools.pkg`