### PR TITLE
Remove Darwin workaround and use Darwin xar

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -92,8 +92,9 @@ if [ "$SDK_VERSION" != "$OLD_SDK_VERSION" ]; then
 fi
 
 # XAR
-
-build_xar
+if [[ $PLATFORM != Darwin ]]; then
+  build_xar
+fi
 
 # XAR END
 
@@ -128,7 +129,9 @@ if [ $f_res -eq 1 ]; then
   if [ $NEED_TAPI_SUPPORT -eq 1 ]; then
     CONFFLAGS+="--with-libtapi=$TARGET_DIR "
   fi
-  CONFFLAGS+="--with-libxar=$TARGET_DIR "
+  if [[ $PLATFORM != Darwin ]]; then
+    CONFFLAGS+="--with-libxar=$TARGET_DIR "
+  fi
   [ -n "$DISABLE_CLANG_AS" ] && CONFFLAGS+="--disable-clang-as "
   [ -n "$DISABLE_LTO_SUPPORT" ] && CONFFLAGS+="--disable-lto-support "
   ./configure $CONFFLAGS

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -50,15 +50,6 @@ if [[ $PLATFORM == CYGWIN* ]]; then
   exit 1
 fi
 
-if [[ $PLATFORM == Darwin ]]; then
-  echo $PATH
-  CFLAGS_OPENSSL="$(pkg-config --cflags openssl)"
-  LDFLAGS_OPENSSL="$(pkg-config --libs-only-L openssl)"
-  export C_INCLUDE_PATH=${CFLAGS_OPENSSL:2}
-  export CPLUS_INCLUDE_PATH=${CFLAGS_OPENSSL:2}
-  export LIBRARY_PATH=${LDFLAGS_OPENSSL:2}
-fi
-
 function require()
 {
   if ! command -v $1 &>/dev/null; then


### PR DESCRIPTION
Using macOS shipped xar avoids the need for openssl so also remove the workaround needed to help find openssl headers/libs