### PR TITLE
Make gen_sdk_package.sh better at finding SDKs

### DIFF
--- a/tools/gen_sdk_package.sh
+++ b/tools/gen_sdk_package.sh
@@ -148,10 +148,10 @@ else
   fi
 fi
 
-SDKS=$(ls | grep -E "^MacOSX12.*|^MacOSX11.*|^MacOSX10.*" | grep -v "Patch")
+SDKS=$(ls | grep -E "^MacOSX\d.*" | grep -v Patch || echo)
 
 if [ -z "$SDKS" ]; then
-    echo "No SDK found" 1>&2
+    echo "No SDK found in" $(pwd) 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
I was using an older version of this script and eventually it stopped working because it was only designed to work for macOS version 10, and didn't anticipate version 11 or 12 being released.

In order to prevent that from happening again in a year or two, this pull request removes the hardcoded version numbers and uses a more general regular expression to find SDKs.  Additionally, I fixed it so that an error message is shown if no SDKs are found, which was the original intent of the code.
