### PR TITLE
Add some missing dependencies to the list in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ to the tarballs/ directory.
 
 Then ensure you have the following installed on your system:
 
-`Clang 3.9+`, `cmake`, `git`, `patch`, `Python`, `libssl-devel` (openssl)  
-`lzma-devel`, `libxml2-devel` and the `bash shell`.
+`Clang 3.9+`, `cmake`, `git`, `patch`, `Python`, `libssl-dev` (openssl)
+`lzma-dev`, `libxml2-dev` and the `bash shell`.
 
 You can run 'sudo tools/get\_dependencies.sh' to get these (and the
 optional packages) automatically. (outdated)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ to the tarballs/ directory.
 Then ensure you have the following installed on your system:
 
 `Clang 3.9+`, `cmake`, `git`, `patch`, `Python`, `libssl-dev` (openssl)
-`lzma-dev`, `libxml2-dev` and the `bash shell`.
+`lzma-dev`, `libxml2-dev`, `xz`, `bzip2`, `cpio`, `libbz2`, `zlib1g-dev`
+and the `bash shell`.
 
 You can run 'sudo tools/get\_dependencies.sh' to get these (and the
 optional packages) automatically. (outdated)


### PR DESCRIPTION
Not terribly important but hey i missed those in my container, figured it would help the next person. Also the first commit uses the name of Debian packages instead of Mageia, because one of the missing dependencies was a `-dev`.