### PR TITLE
Allow to pin dependencies

### DIFF
--- a/build_llvm_dsymutil.sh
+++ b/build_llvm_dsymutil.sh
@@ -16,7 +16,8 @@ require cmake
 
 pushd $OSXCROSS_BUILD_DIR &>/dev/null
 
-get_sources https://github.com/tpoechtrager/llvm-dsymutil.git master
+LLVM_DSYMUTIL_REVISION="${LLVM_DSYMUTIL_REVISION:-"master"}"
+get_sources https://github.com/tpoechtrager/llvm-dsymutil.git "$LLVM_DSYMUTIL_REVISION"
 
 if [ $f_res -eq 1 ]; then
   pushd $CURRENT_BUILD_PROJECT_NAME &>/dev/null

--- a/tools/gen_sdk_package_darling_dmg.sh
+++ b/tools/gen_sdk_package_darling_dmg.sh
@@ -49,8 +49,9 @@ set -e
 
 pushd $BUILD_DIR &>/dev/null
 
+DARLING_DMG_REVISION="${DARLING_REVISION:-"master"}"
 FULL_CLONE=1 \
-  get_sources https://github.com/LubosD/darling-dmg.git master
+  get_sources https://github.com/LubosD/darling-dmg.git "$DARLING_DMG_REVISION"
 
 if [ $f_res -eq 1 ]; then
   pushd $CURRENT_BUILD_PROJECT_NAME &>/dev/null

--- a/tools/gen_sdk_package_p7zip.sh
+++ b/tools/gen_sdk_package_p7zip.sh
@@ -38,7 +38,8 @@ if [ ! -f $TARGET_DIR/SDK/tools/bin/7z ]; then
 fi
 
 
-get_sources https://github.com/tpoechtrager/p7zip.git master
+P7ZIP_REVISION="${P7ZIP_REVISION:-"master"}"
+get_sources https://github.com/tpoechtrager/p7zip.git "$P7ZIP_REVISION"
 
 if [ $f_res -eq 1 ]; then
   pushd $CURRENT_BUILD_PROJECT_NAME &>/dev/null

--- a/tools/gen_sdk_package_pbzx.sh
+++ b/tools/gen_sdk_package_pbzx.sh
@@ -22,7 +22,8 @@ pushd $BUILD_DIR &>/dev/null
 
 build_xar
 
-get_sources https://github.com/tpoechtrager/pbzx.git master
+PBZX_REVISION="${PBZX_REVISION:-"master"}"
+get_sources https://github.com/tpoechtrager/pbzx.git "$PBZX_REVISION"
 
 if [ $f_res -eq 1 ]; then
   pushd $CURRENT_BUILD_PROJECT_NAME &>/dev/null

--- a/tools/gen_sdk_package_tools_dmg.sh
+++ b/tools/gen_sdk_package_tools_dmg.sh
@@ -51,7 +51,8 @@ if [ $f_res -eq 1 ]; then
 fi
 
 # build 7z
-get_sources https://github.com/tpoechtrager/p7zip.git master
+P7ZIP_REVISION="${P7ZIP_REVISION:-"master"}"
+get_sources https://github.com/tpoechtrager/p7zip.git "$P7ZIP_REVISION"
 
 if [ $f_res -eq 1 ]; then
   pushd $CURRENT_BUILD_PROJECT_NAME &>/dev/null

--- a/tools/gen_sdk_package_tools_dmg.sh
+++ b/tools/gen_sdk_package_tools_dmg.sh
@@ -37,7 +37,8 @@ require cpio
 build_xar
 
 # build pbzx
-get_sources https://github.com/tpoechtrager/pbzx.git master
+PBZX_REVISION="${PBZX_REVISION:-"master"}"
+get_sources https://github.com/tpoechtrager/pbzx.git "$PBZX_REVISION"
 
 if [ $f_res -eq 1 ]; then
   pushd $CURRENT_BUILD_PROJECT_NAME &>/dev/null

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -481,7 +481,8 @@ function build_xar()
 {
   pushd $BUILD_DIR &>/dev/null
 
-  get_sources https://github.com/tpoechtrager/xar.git master
+  XAR_REVISION="${XAR_REVISION:-"master"}"
+  get_sources https://github.com/tpoechtrager/xar.git "$XAR_REVISION"
 
   if [ $f_res -eq 1 ]; then
     pushd $CURRENT_BUILD_PROJECT_NAME/xar &>/dev/null


### PR DESCRIPTION
The various scripts will at the moment always pull the master branch of each of the projects. This introduces a way to fetch a specific commit per project with minimal changes.

Specifying a specific commit for the project you use is useful for (at least):
- Pinning a known-working version: a user might not want to unexpectedly have to debug your build if for some reason the latest push on one of the upstream makes an incompatible change.
- [Reproducible builds](https://reproducible-builds.org/): it is very unlikely you'd keep having the same binaries if the toolchain you use is a moving target.

It might not be relevant for all project pulled in the scripts (for instance i'm not sure about `darling`)?