### PR TITLE
WIP: feat: add support for GCC targeting darwin arm64

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 ### WHAT IS THE GOAL OF OSXCROSS? ###
 
-The goal of OSXCross is to provide a well working macOS cross toolchain for  
+The goal of OSXCross is to provide a well working macOS cross toolchain for
 `Linux`, `FreeBSD`, `OpenBSD`, and `Android (Termux)`.
 
-OSXCross works **on** `x86`, `x86_64`, `arm` and `AArch64`/`arm64`,  
+OSXCross works **on** `x86`, `x86_64`, `arm` and `AArch64`/`arm64`,
 and is able to **target** `arm64`, `arm64e`, `x86_64`, `x86_64h` and `i386`.
 
-`arm64` requires macOS 11.0 SDK (or later).  
+`arm64` requires macOS 11.0 SDK (or later).
 `arm64e` [requires a recent Apple clang compiler.](https://github.com/apple/llvm-project)
 
 ### HOW DOES IT WORK? ###
@@ -55,7 +55,7 @@ to the tarballs/ directory.
 
 Then ensure you have the following installed on your system:
 
-`Clang 3.9+`, `cmake`, `git`, `patch`, `Python`, `libssl-devel` (openssl)  
+`Clang 3.9+`, `cmake`, `git`, `patch`, `Python`, `libssl-devel` (openssl)
 `lzma-devel`, `libxml2-devel` and the `bash shell`.
 
 You can run 'sudo tools/get\_dependencies.sh' to get these (and the
@@ -145,19 +145,25 @@ Fortran compiler as well:
 
 \[A gfortran usage example can be found [here](https://github.com/tpoechtrager/osxcross/issues/28#issuecomment-67047134)]
 
+You can build GCC targeting arm64 using this command:
+
+```shell
+    GCC_VERSION=13.0.1 TARGET_ARCHITECTURE=aarch64  ./build_gcc.sh
+```
+
 Before you do this, make sure you have the GCC build depedencies installed on
 your system.
 
 On debian like systems you can install these using:
 
 ```shell
-    sudo apt-get install gcc g++ zlib1g-dev libmpc-dev libmpfr-dev libgmp-dev
+    sudo apt-get install gcc g++ zlib1g-dev libmpc-dev libmpfr-dev libgmp-dev flex
 ```
 
 ATTENTION:
 
-OSXCross does not enable `-Werror=implicit-function-declaration` by default.  
-You can emulate Xcode 12's behavior by setting the environmental variable  
+OSXCross does not enable `-Werror=implicit-function-declaration` by default.
+You can emulate Xcode 12's behavior by setting the environmental variable
 `OSXCROSS_ENABLE_WERROR_IMPLICIT_FUNCTION_DECLARATION` to 1.
 
 OSXCross links libgcc and libstdc++ statically by default (this affects
@@ -185,19 +191,19 @@ Tools for Xcode.
 5. (On Linux/BSD) Copy or move the SDK into the tarballs/ directory of
    OSXCross.
 
-\*\*  
--- Xcode up to 12.5 Beta 3 is known to work.  
+\*\*
+-- Xcode up to 12.5 Beta 3 is known to work.
 -- Use Firefox if you have problems signing in.
 
-\*\*\*  
--- If you get a dialog with a crossed circle, ignore it.  
+\*\*\*
+-- If you get a dialog with a crossed circle, ignore it.
 -- You don't need to install Xcode.
 
 Step 1. and 2. can be skipped if you have Xcode installed.
 
 ##### Packing the SDK on Linux - Method 1 (Xcode > 8.0): #####
 
-This method may require up to 45 GB of free disk space.  
+This method may require up to 45 GB of free disk space.
 An SSD is recommended for this method.
 
 1. Download Xcode like described in 'Packaging the SDK on macOS'
@@ -356,9 +362,9 @@ Usage Examples:
 
 ### DEPLOYMENT TARGET: ###
 
-The default deployment target is:  
+The default deployment target is:
 
-SDK <= 10.13: `macOS 10.6`  
+SDK <= 10.13: `macOS 10.6`
 SDK >= 10.14: `macOS 10.9`
 
 However, there are several ways to override the default value:
@@ -367,17 +373,17 @@ However, there are several ways to override the default value:
 2. by passing `-mmacosx-version-min=10.x` to the compiler
 3. by setting the `MACOSX_DEPLOYMENT_TARGET` environment variable
 
-\>= 10.9 also defaults to `libc++` instead of `libstdc++`,  
+\>= 10.9 also defaults to `libc++` instead of `libstdc++`,
 this behavior can be overriden by explicitly passing `-stdlib=libstdc++` to clang.
 
-x86\_64h defaults to `macOS 10.8` and requires clang 3.5+.  
+x86\_64h defaults to `macOS 10.8` and requires clang 3.5+.
 x86\_64h = x86\_64 with optimizations for the Intel Haswell Architecture.
 
 ### PROJECTS USING OSXCROSS: ###
 
-* [multiarch/crossbuild](https://github.com/multiarch/crossbuild):  
-  various cross-compilers  
-  (**Systems**: Linux, macOS, Windows, **Archs**: x86\_64,i386, arm, ppc, mips)  
+* [multiarch/crossbuild](https://github.com/multiarch/crossbuild):
+  various cross-compilers
+  (**Systems**: Linux, macOS, Windows, **Archs**: x86\_64,i386, arm, ppc, mips)
   in Docker. OSXCross powers the Darwin builds.
 * [Smartmontools](https://www.smartmontools.org)
 

--- a/tools/get_dependencies.sh
+++ b/tools/get_dependencies.sh
@@ -44,7 +44,7 @@ get_debian_deps()
 {
  apt-get install -y --force-yes clang llvm-dev libxml2-dev uuid-dev \
   libssl-dev bash patch make tar xz-utils bzip2 gzip sed cpio libbz2-dev \
-  zlib1g-dev
+  zlib1g-dev cmake
 }
 
 get_arch_deps()
@@ -90,5 +90,3 @@ elif [ "`uname | grep -i netbsd`" ]; then
 else
  unknown
 fi
-
-


### PR DESCRIPTION
I was able to get a working compiler targeting darwin 13.0 arm64. It uses [an experimental GCC fork](https://github.com/iains/gcc-darwin-arm64).

It required the following change to [cctools](https://github.com/tpoechtrager/cctools-port).

```
diff --git a/cctools/ld64/src/ld/PlatformSupport.cpp b/cctools/ld64/src/ld/PlatformSupport.cpp
index 4869542..e081478 100644
--- a/cctools/ld64/src/ld/PlatformSupport.cpp
+++ b/cctools/ld64/src/ld/PlatformSupport.cpp
@@ -105,7 +105,7 @@ void VersionSet::checkObjectCrosslink(const VersionSet& objectPlatforms, const s
                 if (enforce == PlatEnforce::warnInternalErrorExternal) {
                     enforce = (internalSDK ? PlatEnforce::warning : PlatEnforce::error);
                 }
-                if ( platformMismatchesAreWarning && (enforce == PlatEnforce::error) )
+                if ( true && (enforce == PlatEnforce::error) )
                     enforce = PlatEnforce::warning;
                 switch (enforce) {
                     case PlatEnforce::allow:
```

Note: this results in a ton of warnings from `ld`. It thinks we're linking to iOS and not macOS. I think this is an issue with GCC. The resulting binaries seem to be fine.
