### PR TITLE
osxcross-macports: update macOS -> darwin mapping

### DIFF
--- a/tools/osxcross-macports
+++ b/tools/osxcross-macports
@@ -81,8 +81,9 @@ case $MACOSX_DEPLOYMENT_TARGET in
   10.14* ) OSXVERSION="darwin_18" ;;
   10.15* ) OSXVERSION="darwin_19" ;;
   10.16* ) OSXVERSION="darwin_20" ;;
-  11.*   ) OSXVERSION="darwin_21" ;;
+  11.*   ) OSXVERSION="darwin_20" ;;
   12.*   ) OSXVERSION="darwin_21" ;;
+  13.*   ) OSXVERSION="darwin_22" ;;
        * ) unsupportedDepTarget ;;
 esac
 


### PR DESCRIPTION
macOS 11.* should map to darwin_20
macOS 13.* should map to darwin_22

macOS 12.* was already correctly set to darwin_21

This follows the logic from https://trac.macports.org/wiki/XcodeVersionInfo#macOSVersionMap and https://en.wikipedia.org/wiki/Darwin_(operating_system)#Darwin_20_onwards