### PR TITLE
Usable OS X Cross PPC Toolchain with Mainline GCC-5.5.0

### DIFF
--- a/README.PPC-GCC-5.5.0-SDK-10.5.md
+++ b/README.PPC-GCC-5.5.0-SDK-10.5.md
@@ -43,7 +43,7 @@ The GNU STDC++ is statically linked so that we do not have to hastle with it.
 I am able to build and run C99, C11, C++03, C++11, and C++14 code.
 
 
-#### PowerPC364 ####
+#### PowerPC64 ####
 
 C, C++, and Fortran compilers are able to build code. I do not have a PowerPC64
 Mac to test on at the moment.
@@ -143,7 +143,7 @@ git clone \
 cd osxcross-ppc-202308
 
 # Add target/bin to the beginning of PATH:
-export export PATH="$(pwd)/target/bin:${PATH}"
+export PATH="$(pwd)/target/bin:${PATH}"
 ```
 
 
@@ -172,7 +172,7 @@ tar czf ./tarballs/MacOSX10.5.sdk.tar.gz MacOSX10.5.sdk
 
 #### Build OS X Cross: ####
 
-Build OS X Cross. They will be staged in `$(pwd)/target/bin` thich needs to be
+Build OS X Cross. They will be staged in `$(pwd)/target/bin` wich needs to be
 at the beginning of PATH:
 
 ```
@@ -207,11 +207,11 @@ powerpc64-apple-darwin9-sw_vers
 
 This builds the mainline GCC-5.5.0 to target MacOS-10.5 PowerPC and PowerPC64.
 
-**NOTE:** The SDK C++ headers break the GCC build and the resulting C++ compiler
+**NOTE:** The SDK C++ headers break the GCC build and the resulting C++ compiler.
 To work around this issue, we move them to hide them from GCC. Since we will only
 be using GCC with this toolchain from now on and not Clang, this seems fine. We
 had to wait to move them, until after the OS X Cross tools are built with Clang.
-Because Cland does needs these headers. After the OS X Cross tools are built and
+Because Clang does need these headers. After the OS X Cross tools are built and
 are usable, we no longer need Clang or these headers to build anything else.
 
 ```
@@ -246,7 +246,7 @@ Some scripts to test the toolchain:
 single source files.
 
 `test_autotools.sh`: Builds a number of non-trivial Autotools Configured projects
-from recent versions of theie mainline source. This includes OpenSSL, WGet
+from recent versions of their mainline source. This includes OpenSSL, WGet
 and CURL.
 
 
@@ -273,13 +273,13 @@ The following programs are built:
    - CCPROG01: C89 Helloworld Program:
    - CCPROG02: C11 Program Using PThreads:
    - CXPROG01: C++03 Helloworld Program:
-   - CXPROG02: C++11 Program Using ::std::thread:
+   - CXPROG02: C++11 Program Using ::std ::thread:
    - CXPROG03: C++11 Program Using Lamdas:
    - CXPROG04: C++14 Program Using Auto Lamda Parameter:
    - CXPROG05: C++14 Program Using ::std::shared_timed_mutex:
 
 **NOTE:**: `::std::shared_timed_mutex:` was introduced in MacOS-10.12. Since we
-are using the GNU STDC++ library, we can now use these C++14 features in
+are using the GNU STDC++ library, we can now use these advanced C++14 features in
 programs running on MacOS-10.5 and PowerPC targets.
 
 Run the test:
@@ -335,7 +335,8 @@ OSXCROSS_TEST_ARCH=powerpc64 ./test_autotools.sh
 
 ### TODO: ###
 
-1. Test the PowerPC64 builds. I do not have access to one at this time.
+1. Test the PowerPC64 builds. I do not have access to a PowerPC64 Mac at this
+time.
 
 2. Automatically statically link the libgcc_s and libatomic. That way noone has
 to hastle with them. Maybe the wrapper can do it in a similar fashion as the

--- a/README.PPC-GCC-5.5.0-SDK-10.5.md
+++ b/README.PPC-GCC-5.5.0-SDK-10.5.md
@@ -1,0 +1,348 @@
+## OS X Cross toolchain GCC-5.5.0 and MacOS SDK-10.5 targeting PowerPC and PowerPC64 ##
+
+
+### Introduction: ###
+
+These detailed instructions on how I was able to use the `ppc-test` branch of the
+[osxcross](https://github.com/tpoechtrager/osxcross) project to build a toolchain
+on an Ubuntu16 build host to target MacOS-10.5 PowerPC and PowerPC64 using the
+mainline GCC-5.5.0. This toolchain supports C (C89, C90, C11), C++ (up to C++14),
+and GNU Fortran (F77 and F90).
+
+From my testing so far, the toolchain is working flawlessly. I have provided some
+scripts to test the toolchain. See the toolchain test section below.
+
+**NOTE:** MakcOS-10.5 does not have native support for C++11 or any recent C++
+standards. With OS X Cross, we can use the GCC-5.5.0 and the GNU STDC++ runtime
+library provided by that toolchain to build and run C++11 and C++14 code on
+MacOS-10.5 PowerPC targets.
+
+**NOTE:** I had to make slight modifications to the `build_gcc.sh` script in
+order for it to retrieve the mainline GCC-5.5.0 source and to download the
+build prerequisites.
+
+My journey to creating this toolchain started
+[here](https://github.com/tpoechtrager/osxcross/issues/50).
+
+---
+
+
+### What is Working: ###
+
+
+#### PowerPC32: ####
+
+C and C++ compilers are able to build code that runs on my iBook G4.
+C++03, C++11, C++14 programs can be built and run well on the iBook G4.
+
+```
+Darwin ibook-g4.local 9.8.0 Darwin Kernel Version 9.8.0: Wed Jul 15 16:57:01 PDT 2009; root:xnu-1228.15.4~1/RELEASE_PPC Power Macintosh
+```
+
+The GNU STDC++ is statically linked so that we do not have to hastle with it.
+I am able to build and run C99, C11, C++03, C++11, and C++14 code.
+
+
+#### PowerPC364 ####
+
+C, C++, and Fortran compilers are able to build code. I do not have a PowerPC64
+Mac to test on at the moment.
+
+The GNU STDC++ is statically linked so that we do not have to hastle with it.
+I am able to build Fortran77, Fortran90, C99, C11, C++03, C++11, and C++14 code.
+
+---
+
+
+### What is Not Working: ###
+
+
+#### PowerPC32: ####
+
+The PPC32 Fortran compiler is not being staged (or built?). I dont know why this
+is happening.
+
+
+#### PowerPC364 ####
+
+The PPC64 compiler reports warning that it cannot find apple gcc intrinsic
+headers. The toolchain seems to work regardless. I dont know how to resolve this
+issue or it it even matters.
+
+```
+osxcross: warning: cannot find apple gcc intrinsic headers; please report this issue to the OSXCross project
+```
+
+---
+
+
+### Prepare the Build Host: ####
+
+I am using an Ubuntu16 VM:
+
+```
+lsb_release -a
+   LSB Version:    core-9.20160110ubuntu0.2-amd64:..
+   Distributor ID: Ubuntu
+   Description:    Ubuntu 16.04.7 LTS
+   Release:        16.04
+   Codename:       xenial
+
+```
+
+The following packages are installed:
+
+```
+sudo apt install -y ubuntu-standard
+sudo apt install -y build-essential
+sudo apt install -y clang
+sudo apt install -y perl
+sudo apt install -y python
+sudo apt install -y wget
+sudo apt install -y libxml2-dev
+sudo apt install -y uuid-dev
+```
+
+The following package versions are installed:
+
+```
+BASH: v4.3.48
+GLIBC: v2.23
+GNU Make: v4.1
+Binutils: v2.26.1
+GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.12) 5.4.0 20160609
+Clang: v3.8.0-2ubuntu4
+Perl: v5.22.1
+Python: v2.7.12
+WGet: v1.17.1
+libxml2-dev: v2.9.3
+uuid-dev: v2.27.1
+
+```
+
+---
+
+
+### Build the Toolchain: ####
+
+
+#### Clone my OS X Cross Branch: ####
+
+I have had to make a few minor changes to the `build_gcc.sh`, some scripts that
+can be used to test the Toolchain, and detailed instructions on how I built this
+toolchain. This is currently in an unmerged branch.
+
+```
+# Clone the unmerged branch:
+git clone \
+   -b ppc-test-202308 \
+   https://github.com/jlsantiago0/osxcross.git \
+   osxcross-ppc-202308
+
+# Change directories:
+cd osxcross-ppc-202308
+
+# Add target/bin to the beginning of PATH:
+export export PATH="$(pwd)/target/bin:${PATH}"
+```
+
+
+#### Obtain the MacOS-10.5 SDK: ####
+
+Obtain and repackage the MacOS-10.5 SDK.
+
+I obtained the SDK from [here](https://github.com/phracker/MacOSX-SDKs/releases).
+Other options are discussed
+[here](https://github.com/tpoechtrager/osxcross/blob/master/README.md).
+
+**NOTE:** We need to repackage the SDK as .tar.gz so that the scripts can find
+it.
+
+```
+# Obtain the SDK:
+wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.5.sdk.tar.xz
+
+# Extract it:
+tar xf ./MacOSX10.5.sdk.tar.xz
+
+# Repackage the SDK as .tar.gz so that the scripts can find it:
+tar czf ./tarballs/MacOSX10.5.sdk.tar.gz MacOSX10.5.sdk
+```
+
+
+#### Build OS X Cross: ####
+
+Build OS X Cross. They will be staged in `$(pwd)/target/bin` thich needs to be
+at the beginning of PATH:
+
+```
+CDEBUG=1 UNATTENDED=1 SDK_VERSION=10.5 ./build.sh
+```
+
+Ensure that `xcrun` is working:
+
+```
+which xcrun
+xcrun -f ar
+xcrun -f otool
+xcrun otool -arch all --version
+xcrun --show-sdk-version
+xcrun --show-sdk-path
+```
+
+Ensure that the tools run:
+
+```
+which powerpc-apple-darwin9-sw_vers
+powerpc-apple-darwin9-sw_vers
+
+which powerpc64-apple-darwin9-sw_vers
+powerpc64-apple-darwin9-sw_vers
+```
+
+**NOTE:** dsymutil does not seem to support PowerPC targets. So not building it.
+
+
+#### Build GCC-5.5.0: ####
+
+This builds the mainline GCC-5.5.0 to target MacOS-10.5 PowerPC and PowerPC64.
+
+**NOTE:** The SDK C++ headers break the GCC build and the resulting C++ compiler
+To work around this issue, we move them to hide them from GCC. Since we will only
+be using GCC with this toolchain from now on and not Clang, this seems fine. We
+had to wait to move them, until after the OS X Cross tools are built with Clang.
+Because Cland does needs these headers. After the OS X Cross tools are built and
+are usable, we no longer need Clang or these headers to build anything else.
+
+```
+# **NOTE:** the `SDK/include/c++/4.0.0` directory causes issues building GCC and
+#  breaks the resulting C++ compiler for PowerPC64. Moving the directory will
+#  hide them from GCC.
+mv ./target/SDK/MacOSX10.5.sdk/usr/include/c++/4.0.0 \
+   ./target/SDK/MacOSX10.5.sdk/usr/include/c++/4.0.0.dontuse
+```
+Build mainline GCC-5.5.0 to target MacOS-10.5 PowerPC:
+
+```
+# Build GCC for POWERPC targets
+DEBUG=1 UNATTENDED=1 GCC_VERSION=5.5.0 ENABLE_FORTRAN=1 POWERPC=1 \
+   ./build_gcc.sh
+
+# Make sure it runs:
+which powerpc-apple-darwin9-gcc
+powerpc-apple-darwin9-gcc --version
+which powerpc64-apple-darwin9-gcc
+powerpc64-apple-darwin9-gcc --version
+```
+
+---
+
+
+### Test the Toolchain: ####
+
+Some scripts to test the toolchain:
+
+`test_simple.sh`: Builds some perhaps trivial C, C++, and Fortran programs from
+single source files.
+
+`test_autotools.sh`: Builds a number of non-trivial Autotools Configured projects
+from recent versions of theie mainline source. This includes OpenSSL, WGet
+and CURL.
+
+
+#### Build Some Simple Programs: ####
+
+The script `test_simple.sh` generates single source file programs and compiles
+them using this toolchain. Coverage includes: C (C89 and C11),
+C++ (C++03, C++11, C++14), and Fortran (Fortran77 and Fortran90).
+
+Requires the OSX Cross stage directory `target/bin` at the beginning of PATH and
+`xcrun -f cc` must provide the C compiler program information.
+
+**NOTE:** Environment variables that effect the test script operations:
+
+```
+# Set the test architecture to use:
+OSXCROSS_TEST_ARCH=powerpc|powerpc64
+```
+
+The following programs are built:
+
+   - FFPROG01: Fortran77 Helloworld Program:
+   - FFPROG02: Fortran90 Helloworld Program:
+   - CCPROG01: C89 Helloworld Program:
+   - CCPROG02: C11 Program Using PThreads:
+   - CXPROG01: C++03 Helloworld Program:
+   - CXPROG02: C++11 Program Using ::std::thread:
+   - CXPROG03: C++11 Program Using Lamdas:
+   - CXPROG04: C++14 Program Using Auto Lamda Parameter:
+   - CXPROG05: C++14 Program Using ::std::shared_timed_mutex:
+
+**NOTE:**: `::std::shared_timed_mutex:` was introduced in MacOS-10.12. Since we
+are using the GNU STDC++ library, we can now use these C++14 features in
+programs running on MacOS-10.5 and PowerPC targets.
+
+Run the test:
+
+```
+# Target PowerPC:
+# Results will be in ./test/powerpc/:
+OSXCROSS_TEST_ARCH=powerpc ./test_simple.sh
+
+# Target PowerPC64:
+# Results will be in ./test/powerpc64/:
+OSXCROSS_TEST_ARCH=powerpc64 ./test_simple.sh
+```
+
+
+#### Build Some Non-Trivial Autotools Configured Projects: ####
+
+The script `test_autotools.sh` downloads the mainline source for recent versions
+of OpenSSL, WGet and CURL and builds them using this toolchain.
+
+Requires the OSX Cross stage directory `target/bin` at the beginning of PATH and
+`xcrun -f cc` must provide the C compiler program information.
+
+**NOTE:** Environment variables that effect the test script operations:
+
+```
+# Set the test architecture to use:
+OSXCROSS_TEST_ARCH=powerpc|powerpc64
+
+# Trigger a rebuild of everything:
+OSXCROSS_TEST_REBUILD=0|1
+
+# Project Versions:
+OSXCROSS_TEST_OPENSSL_VERSION=3.1.2
+OSXCROSS_TEST_WGET_VERSION=1.21.4
+OSXCROSS_TEST_CURL_VERSION=8.2.1
+```
+
+Run the test:
+
+```
+# Target PowerPC:
+# Results will be in ./test/powerpc/:
+OSXCROSS_TEST_ARCH=powerpc ./test_autotools.sh
+
+# Target PowerPC64:
+# Results will be in ./test/powerpc64/:
+OSXCROSS_TEST_ARCH=powerpc64 ./test_autotools.sh
+```
+
+---
+
+
+### TODO: ###
+
+1. Test the PowerPC64 builds. I do not have access to one at this time.
+
+2. Automatically statically link the libgcc_s and libatomic. That way noone has
+to hastle with them. Maybe the wrapper can do it in a similar fashion as the
+GNU STDC++ library is handled by the toolchain.
+
+3. Create a test for a non-trivial CMake project. Perhaps auto generate a CMake
+Toolchain file to use with the OS X Cross Toolchain.
+
+4. Try to replicate this with a newer GCC Toolchain. Perhaps GCC-10.5.0
+or GCC-13.x.

--- a/README.PPC-GCC-5.5.0-SDK-10.5.md
+++ b/README.PPC-GCC-5.5.0-SDK-10.5.md
@@ -248,7 +248,7 @@ single source files.
 
 `test_autotools.sh`: Builds a number of non-trivial Autotools Configured projects
 from recent versions of their mainline source. This includes OpenSSL, WGet
-and CURL.
+CURL, ZSTD, and libsodium.
 
 
 #### Build Some Simple Programs: ####
@@ -301,7 +301,7 @@ OSXCROSS_TEST_ARCH=powerpc64 ./test_simple.sh
 #### Build Some Non-Trivial Autotools Configured Projects: ####
 
 The script `test_autotools.sh` downloads the mainline source for recent versions
-of OpenSSL, WGet and CURL and builds them using this toolchain.
+of OpenSSL, WGet, CURL, ZSTD, and libsodium and builds them using this toolchain.
 
 Requires the OS X Cross stage directory `target/bin` at the beginning of `PATH`
 and `xcrun -f cc` must provide the C compiler program information.
@@ -319,6 +319,8 @@ OSXCROSS_TEST_REBUILD=0|1
 OSXCROSS_TEST_OPENSSL_VERSION=3.1.2
 OSXCROSS_TEST_WGET_VERSION=1.21.4
 OSXCROSS_TEST_CURL_VERSION=8.2.1
+OSXCROSS_TEST_ZSTD_VERSION=1.5.2
+OSXCROSS_TEST_LIBSODIUM_VERSION=1.0.18
 ```
 
 Run the test:

--- a/README.PPC-GCC-5.5.0-SDK-10.5.md
+++ b/README.PPC-GCC-5.5.0-SDK-10.5.md
@@ -273,7 +273,7 @@ The following programs are built:
    - CCPROG01: C89 Helloworld Program:
    - CCPROG02: C11 Program Using PThreads:
    - CXPROG01: C++03 Helloworld Program:
-   - CXPROG02: C++11 Program Using ::std ::thread:
+   - CXPROG02: C++11 Program Using `::std::thread`:
    - CXPROG03: C++11 Program Using Lamdas:
    - CXPROG04: C++14 Program Using Auto Lamda Parameter:
    - CXPROG05: C++14 Program Using ::std::shared_timed_mutex:

--- a/README.PPC-GCC-5.5.0-SDK-10.5.md
+++ b/README.PPC-GCC-5.5.0-SDK-10.5.md
@@ -87,7 +87,6 @@ lsb_release -a
    Description:    Ubuntu 16.04.7 LTS
    Release:        16.04
    Codename:       xenial
-
 ```
 
 The following packages are installed:
@@ -117,7 +116,6 @@ Python: v2.7.12
 WGet: v1.17.1
 libxml2-dev: v2.9.3
 uuid-dev: v2.27.1
-
 ```
 
 ---
@@ -128,9 +126,9 @@ uuid-dev: v2.27.1
 
 #### Clone my OS X Cross Branch: ####
 
-I have had to make a few minor changes to the `build_gcc.sh`, some scripts that
-can be used to test the Toolchain, and detailed instructions on how I built this
-toolchain. This is currently in an unmerged branch.
+I have had to make a few minor changes to the `build_gcc.sh`, added some scripts
+that can be used to test the Toolchain, and added detailed instructions on how I
+built this toolchain. This is currently in an unmerged branch.
 
 ```
 # Clone the unmerged branch:
@@ -172,7 +170,7 @@ tar czf ./tarballs/MacOSX10.5.sdk.tar.gz MacOSX10.5.sdk
 
 #### Build OS X Cross: ####
 
-Build OS X Cross. They will be staged in `$(pwd)/target/bin` wich needs to be
+Build OS X Cross. They will be staged in `$(pwd)/target/bin` which needs to be
 at the beginning of `PATH`:
 
 ```
@@ -221,6 +219,7 @@ are usable, we no longer need Clang or these headers to build anything else.
 mv ./target/SDK/MacOSX10.5.sdk/usr/include/c++/4.0.0 \
    ./target/SDK/MacOSX10.5.sdk/usr/include/c++/4.0.0.dontuse
 ```
+
 Build mainline GCC-5.5.0 to target MacOS-10.5 PowerPC:
 
 ```

--- a/README.PPC-GCC-5.5.0-SDK-10.5.md
+++ b/README.PPC-GCC-5.5.0-SDK-10.5.md
@@ -174,6 +174,7 @@ Build OS X Cross. They will be staged in `$(pwd)/target/bin` which needs to be
 at the beginning of `PATH`:
 
 ```
+# Build OS X Cross:
 CDEBUG=1 UNATTENDED=1 SDK_VERSION=10.5 ./build.sh
 ```
 
@@ -198,7 +199,8 @@ which powerpc64-apple-darwin9-sw_vers
 powerpc64-apple-darwin9-sw_vers
 ```
 
-**NOTE:** dsymutil does not seem to support PowerPC targets. So not building it.
+**NOTE:** `dsymutil` does not seem to support PowerPC targets. So not building
+it.
 
 
 #### Build GCC-5.5.0: ####
@@ -276,6 +278,8 @@ The following programs are built:
    - CXPROG03: C++11 Program Using Lamdas:
    - CXPROG04: C++14 Program Using Generic Lamdas:
    - CXPROG05: C++14 Program Using `::std::shared_timed_mutex`:
+   - CXPROG06: C++17 Program Using `::std::string_view`:
+   - CXPROG07: C++17 Program Using `::std::shared_mutex`:
 
 **NOTE:**: `::std::shared_timed_mutex:` was introduced in MacOS-10.12. Since we
 are using the GNU STDC++ library, we can now use these advanced C++14 features in

--- a/README.PPC-GCC-5.5.0-SDK-10.5.md
+++ b/README.PPC-GCC-5.5.0-SDK-10.5.md
@@ -66,8 +66,8 @@ is happening.
 #### PowerPC364 ####
 
 The PPC64 compiler reports warning that it cannot find apple gcc intrinsic
-headers. The toolchain seems to work regardless. I dont know how to resolve this
-issue or it it even matters.
+headers. The toolchain seems to work regardless. I don't know how to resolve this
+issue or if it even matters.
 
 ```
 osxcross: warning: cannot find apple gcc intrinsic headers; please report this issue to the OSXCross project
@@ -155,7 +155,7 @@ I obtained the SDK from [here](https://github.com/phracker/MacOSX-SDKs/releases)
 Other options are discussed
 [here](https://github.com/tpoechtrager/osxcross/blob/master/README.md).
 
-**NOTE:** We need to repackage the SDK as .tar.gz so that the scripts can find
+**NOTE:** We need to repackage the SDK as `.tar.gz` so that the scripts can find
 it.
 
 ```
@@ -173,7 +173,7 @@ tar czf ./tarballs/MacOSX10.5.sdk.tar.gz MacOSX10.5.sdk
 #### Build OS X Cross: ####
 
 Build OS X Cross. They will be staged in `$(pwd)/target/bin` wich needs to be
-at the beginning of PATH:
+at the beginning of `PATH`:
 
 ```
 CDEBUG=1 UNATTENDED=1 SDK_VERSION=10.5 ./build.sh
@@ -256,8 +256,8 @@ The script `test_simple.sh` generates single source file programs and compiles
 them using this toolchain. Coverage includes: C (C89 and C11),
 C++ (C++03, C++11, C++14), and Fortran (Fortran77 and Fortran90).
 
-Requires the OSX Cross stage directory `target/bin` at the beginning of PATH and
-`xcrun -f cc` must provide the C compiler program information.
+Requires the OS X Cross stage directory `target/bin` at the beginning of `PATH`
+and `xcrun -f cc` must provide the C compiler program information.
 
 **NOTE:** Environment variables that effect the test script operations:
 
@@ -276,7 +276,7 @@ The following programs are built:
    - CXPROG02: C++11 Program Using `::std::thread`:
    - CXPROG03: C++11 Program Using Lamdas:
    - CXPROG04: C++14 Program Using Generic Lamdas:
-   - CXPROG05: C++14 Program Using ::std::shared_timed_mutex:
+   - CXPROG05: C++14 Program Using `::std::shared_timed_mutex`:
 
 **NOTE:**: `::std::shared_timed_mutex:` was introduced in MacOS-10.12. Since we
 are using the GNU STDC++ library, we can now use these advanced C++14 features in
@@ -300,8 +300,8 @@ OSXCROSS_TEST_ARCH=powerpc64 ./test_simple.sh
 The script `test_autotools.sh` downloads the mainline source for recent versions
 of OpenSSL, WGet and CURL and builds them using this toolchain.
 
-Requires the OSX Cross stage directory `target/bin` at the beginning of PATH and
-`xcrun -f cc` must provide the C compiler program information.
+Requires the OS X Cross stage directory `target/bin` at the beginning of `PATH`
+and `xcrun -f cc` must provide the C compiler program information.
 
 **NOTE:** Environment variables that effect the test script operations:
 

--- a/README.PPC-GCC-5.5.0-SDK-10.5.md
+++ b/README.PPC-GCC-5.5.0-SDK-10.5.md
@@ -275,7 +275,7 @@ The following programs are built:
    - CXPROG01: C++03 Helloworld Program:
    - CXPROG02: C++11 Program Using `::std::thread`:
    - CXPROG03: C++11 Program Using Lamdas:
-   - CXPROG04: C++14 Program Using Auto Lamda Parameter:
+   - CXPROG04: C++14 Program Using Generic Lamdas:
    - CXPROG05: C++14 Program Using ::std::shared_timed_mutex:
 
 **NOTE:**: `::std::shared_timed_mutex:` was introduced in MacOS-10.12. Since we

--- a/build_gcc.sh
+++ b/build_gcc.sh
@@ -100,7 +100,7 @@ if [ -n "$APPLE_GCC" ]; then
   wget -c "$GCC_MIRROR/tarballs/gcc/gcc-$APPLE_GCC_VERSION.tar.gz"
 else
   if [[ $GCC_VERSION != *-* ]]; then
-    wget -c "$GCC_MIRROR/releases/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2"
+    wget -c "$GCC_MIRROR/releases/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz"
   else
     wget -c "$GCC_MIRROR/snapshots/$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2"
   fi
@@ -113,7 +113,8 @@ rm -rf gcc* 2>/dev/null
 if [ -n "$APPLE_GCC" ]; then
   extract "$OSXCROSS_TARBALL_DIR/gcc-$APPLE_GCC_VERSION.tar.gz" 1
 else
-  extract "$OSXCROSS_TARBALL_DIR/gcc-$GCC_VERSION.tar.bz2" 1
+  extract "$OSXCROSS_TARBALL_DIR/gcc-$GCC_VERSION.tar.gz" 1
+  ( cd ./gcc-$GCC_VERSION/ && ./contrib/download_prerequisites )
 fi
 
 echo ""

--- a/test_autotools.sh
+++ b/test_autotools.sh
@@ -30,6 +30,8 @@ trap "exit 0" INT EXIT TERM HUP PIPE QUIT ILL KILL ABRT
 #  OSXCROSS_TEST_OPENSSL_VERSION=3.1.2
 #  OSXCROSS_TEST_WGET_VERSION=1.21.4
 #  OSXCROSS_TEST_CURL_VERSION=8.2.1
+#  OSXCROSS_TEST_ZSTD_VERSION=1.5.5
+#  OSXCROSS_TEST_LIBSODIUM_VERSION=1.0.18
 ################################################################################
 
 ################################################################################
@@ -123,7 +125,8 @@ then
    OSXCROSS_TEST_REBUILD=1
    ( \
       cd "${OSXCROSS_TEST_DIR}" \
-      && wget https://www.openssl.org/source/"${OSXCROSS_TEST_OPENSSL_PREFIX}".tar.gz \
+      && wget https://www.openssl.org/source/"\
+${OSXCROSS_TEST_OPENSSL_PREFIX}".tar.gz \
    )
 fi
 if [ -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_PREFIX}".tar.gz ]
@@ -157,7 +160,8 @@ then
    rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_TAG}"
    ( \
       cd "${OSXCROSS_TEST_DIR}" \
-      && wget http://ftp.gnu.org/gnu/wget/"${OSXCROSS_TEST_WGET_PREFIX}".tar.gz \
+      && wget http://ftp.gnu.org/gnu/wget/\
+"${OSXCROSS_TEST_WGET_PREFIX}".tar.gz \
    )
 fi
 if [ -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_PREFIX}".tar.gz ]
@@ -190,7 +194,8 @@ then
    rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_TAG}"
    ( \
       cd "${OSXCROSS_TEST_DIR}" \
-      && wget http://curl.haxx.se/download/"${OSXCROSS_TEST_CURL_PREFIX}".tar.gz \
+      && wget http://curl.haxx.se/download/\
+"${OSXCROSS_TEST_CURL_PREFIX}".tar.gz \
    )
 fi
 if [ -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_PREFIX}".tar.gz ]
@@ -211,6 +216,74 @@ then
    ) || {
       echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
          "Failure Uncompressing '${OSXCROSS_TEST_CURL_PREFIX}.tar.gz'." 1>&2
+      exit 1
+   }
+fi
+
+OSXCROSS_TEST_ZSTD_VERSION="${OSXCROSS_TEST_ZSTD_VERSION:-1.5.2}"
+OSXCROSS_TEST_ZSTD_PREFIX="zstd-${OSXCROSS_TEST_ZSTD_VERSION}"
+OSXCROSS_TEST_ZSTD_TAG="${OSXCROSS_TEST_ZSTD_PREFIX}".TAG
+if [ ! -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_PREFIX}".tar.gz ]
+then
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}" \
+      && wget https://github.com/facebook/zstd/releases/download/v1.5.2/\
+"${OSXCROSS_TEST_ZSTD_PREFIX}".tar.gz \
+   )
+fi
+if [ -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_PREFIX}".tar.gz ]
+then
+   echo "Found: '${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_PREFIX}.tar.gz'."
+else
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Cannot retrieve ZSTD Source." 1>&2
+   exit 1
+fi
+if [ ! -d "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_PREFIX}" ]
+then
+   echo "Uncompressing: '${OSXCROSS_TEST_ZSTD_PREFIX}.tar.gz'."
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}" \
+      && tar xf "${OSXCROSS_TEST_ZSTD_PREFIX}".tar.gz \
+   ) || {
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Failure Uncompressing '${OSXCROSS_TEST_ZSTD_PREFIX}.tar.gz'." 1>&2
+      exit 1
+   }
+fi
+
+OSXCROSS_TEST_LIBSODIUM_VERSION="${OSXCROSS_TEST_LIBSODIUM_VERSION:-1.0.18}"
+OSXCROSS_TEST_LIBSODIUM_PREFIX="libsodium-${OSXCROSS_TEST_LIBSODIUM_VERSION}"
+OSXCROSS_TEST_LIBSODIUM_TAG="${OSXCROSS_TEST_LIBSODIUM_PREFIX}".TAG
+if [ ! -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_PREFIX}".tar.gz ]
+then
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}" \
+      && wget https://download.libsodium.org/libsodium/releases/\
+"${OSXCROSS_TEST_LIBSODIUM_PREFIX}".tar.gz \
+   )
+fi
+if [ -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_PREFIX}".tar.gz ]
+then
+   echo "Found: '${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_PREFIX}.tar.gz'."
+else
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Cannot retrieve LIBSODIUM Source." 1>&2
+   exit 1
+fi
+if [ ! -d "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_PREFIX}" ]
+then
+   echo "Uncompressing: '${OSXCROSS_TEST_LIBSODIUM_PREFIX}.tar.gz'."
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}" \
+      && tar xf "${OSXCROSS_TEST_LIBSODIUM_PREFIX}".tar.gz \
+   ) || {
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Failure Uncompressing '${OSXCROSS_TEST_LIBSODIUM_PREFIX}.tar.gz'." 1>&2
       exit 1
    }
 fi
@@ -271,6 +344,11 @@ then
          ${OSXCROSS_TEST_OPENSSL_TARGET} \
          --prefix="${OSXCROSS_TEST_STAGE_DIR}" \
          -latomic \
+      && make clean \
+         CC="${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+         CXX="${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+         AR="${OSXCROSS_TEST_TOOLCHAIN_AR}" \
+         RANLIB="${OSXCROSS_TEST_TOOLCHAIN_RANLIB}" \
       && make install \
          CC="${OSXCROSS_TEST_TOOLCHAIN_CC}" \
          CXX="${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
@@ -292,8 +370,12 @@ then
    echo "======================================================================"
    file "${OSXCROSS_TEST_STAGE_DIR}/bin/openssl"
    xcrun otool -arch all -hvL "${OSXCROSS_TEST_STAGE_DIR}/bin/openssl"
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_STAGE_DIR}/bin/openssl" 2>/dev/null
    file "${OSXCROSS_TEST_STAGE_DIR}/lib/libssl.dylib"
    xcrun otool -arch all -hvL "${OSXCROSS_TEST_STAGE_DIR}/lib/libssl.dylib"
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_STAGE_DIR}/lib/libssl.dylib" 2>/dev/null
 else
    rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_TAG}"
    echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
@@ -320,6 +402,7 @@ then
          --prefix="${OSXCROSS_TEST_STAGE_DIR}" \
          --with-ssl=openssl \
          --with-libssl-prefix="${OSXCROSS_TEST_STAGE_DIR}" \
+      && make clean \
       && make install \
       && touch "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_TAG}" \
    ) || {
@@ -336,6 +419,8 @@ then
    echo "======================================================================"
    file "${OSXCROSS_TEST_STAGE_DIR}/bin/wget"
    xcrun otool -arch all -hvL "${OSXCROSS_TEST_STAGE_DIR}/bin/wget"
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_STAGE_DIR}/bin/wget" 2>/dev/null
 else
    rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_TAG}"
    echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
@@ -362,6 +447,7 @@ then
          --host="${OSXCROSS_TEST_HOST_PREFIX}" \
          --prefix="${OSXCROSS_TEST_STAGE_DIR}" \
          --with-ssl="${OSXCROSS_TEST_STAGE_DIR}" \
+      && make clean \
       && make install \
       && touch "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_TAG}" \
    ) || {
@@ -378,9 +464,110 @@ then
    echo "======================================================================"
    file "${OSXCROSS_TEST_STAGE_DIR}/bin/curl"
    xcrun otool -arch all -hvL "${OSXCROSS_TEST_STAGE_DIR}/bin/curl"
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_STAGE_DIR}/bin/curl" 2>/dev/null
 else
    rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_TAG}"
    echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
       "CURL Objects not Found." 1>&2
+   exit 1
+fi
+
+if [ "${OSXCROSS_TEST_REBUILD}x" = "1x" \
+   -o ! -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_TAG}" \
+   -o ! -e "${OSXCROSS_TEST_STAGE_DIR}/bin/zstd" ]
+then
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_PREFIX}" \
+      && make clean 2>/dev/null \
+   )
+   ( \
+      cd "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_PREFIX}" \
+      && make clean \
+         UNAME=Darwin \
+         PREFIX="${OSXCROSS_TEST_STAGE_DIR}" \
+         CC="${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+         CXX="${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+         AR="${OSXCROSS_TEST_TOOLCHAIN_AR}" \
+         RANLIB="${OSXCROSS_TEST_TOOLCHAIN_RANLIB}" \
+      && make allmost examples \
+         UNAME=Darwin \
+         PREFIX="${OSXCROSS_TEST_STAGE_DIR}" \
+         CC="${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+         CXX="${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+         AR="${OSXCROSS_TEST_TOOLCHAIN_AR}" \
+         RANLIB="${OSXCROSS_TEST_TOOLCHAIN_RANLIB}" \
+      && make install \
+         UNAME=Darwin \
+         PREFIX="${OSXCROSS_TEST_STAGE_DIR}" \
+         CC="${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+         CXX="${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+         AR="${OSXCROSS_TEST_TOOLCHAIN_AR}" \
+         RANLIB="${OSXCROSS_TEST_TOOLCHAIN_RANLIB}" \
+      && touch "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_TAG}" \
+   ) || {
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Failure Building ZSTD." 1>&2
+      exit 1
+   }
+fi
+if [ -e "${OSXCROSS_TEST_STAGE_DIR}/bin/zstd" ]
+then
+   echo
+   echo "======================================================================"
+   echo " ZSTD Build:"
+   echo "======================================================================"
+   file "${OSXCROSS_TEST_STAGE_DIR}/bin/zstd"
+   xcrun otool -arch all -hvL "${OSXCROSS_TEST_STAGE_DIR}/bin/zstd"
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_STAGE_DIR}/bin/zstd" 2>/dev/null
+else
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_ZSTD_TAG}"
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "ZSTD Objects not Found." 1>&2
+   exit 1
+fi
+
+if [ "${OSXCROSS_TEST_REBUILD}x" = "1x" \
+   -o ! -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_TAG}" \
+   -o ! -e "${OSXCROSS_TEST_STAGE_DIR}/lib/libsodium.dylib" ]
+then
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_PREFIX}" \
+      && make clean 2>/dev/null \
+   )
+   ( \
+      cd "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_PREFIX}" \
+      && CC="${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+         CXX="${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+         ./configure \
+         ${OSXCROSS_TEST_LIBSODIUM_TARGET} \
+         --host="${OSXCROSS_TEST_HOST_PREFIX}" \
+         --prefix="${OSXCROSS_TEST_STAGE_DIR}" \
+      && make clean \
+      && make install \
+      && touch "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_TAG}" \
+   ) || {
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Failure Building LIBSODIUM." 1>&2
+      exit 1
+   }
+fi
+if [ -e "${OSXCROSS_TEST_STAGE_DIR}/bin/wget" ]
+then
+   echo
+   echo "======================================================================"
+   echo " LIBSODIUM Build:"
+   echo "======================================================================"
+   file "${OSXCROSS_TEST_STAGE_DIR}/lib/libsodium.dylib"
+   xcrun otool -arch all -hvL "${OSXCROSS_TEST_STAGE_DIR}/lib/libsodium.dylib"
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_STAGE_DIR}/lib/libsodium.dylib" 2>/dev/null
+else
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_LIBSODIUM_TAG}"
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "LIBSODIUM Objects not Found." 1>&2
    exit 1
 fi

--- a/test_autotools.sh
+++ b/test_autotools.sh
@@ -234,8 +234,8 @@ case "${OSXCROSS_TEST_ARCH}" in
       OSXCROSS_TEST_OPENSSL_TARGET="darwin64-x86_64-cc"
       ;;
    i[3456]86)
-      # Perhaps 'darwin-i386-cc i386 no-asm' instead?
-      OSXCROSS_TEST_OPENSSL_TARGET="darwin-i386-cc i386"
+      #OSXCROSS_TEST_OPENSSL_TARGET="BSD-generic32 no-asm"
+      OSXCROSS_TEST_OPENSSL_TARGET="darwin-i386-cc 386 no-asm"
       ;;
    powerpc64)
       OSXCROSS_TEST_OPENSSL_TARGET="darwin64-ppc-cc"

--- a/test_autotools.sh
+++ b/test_autotools.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+
+trap "exit 0" INT EXIT TERM HUP PIPE QUIT ILL KILL ABRT
+
+################################################################################
+# OS X Cross Build Test Some Non-Trivial Autotools Configured Projects:
+################################################################################
+# This script downloads mainline sources for several non-trivial and recent
+#  Autotool configured projects and build them from source using the OS X Cross
+#  toolchain.
+################################################################################
+# NOTE: The OS X Cross stage directory target/bin is assumed to be at the
+#  beginning of the PATH.
+#
+# The following command must be able to locate the toolchain compilers:
+#
+#     xcrun -f cc
+################################################################################
+# The following environment variables effect the operation of this script:
+#
+#  # Set the test architecture to use:
+#  OSXCROSS_TEST_ARCH=aarch64|arm64
+#  OSXCROSS_TEST_ARCH=x86_64|x86_64h|i386
+#  OSXCROSS_TEST_ARCH=powerpc|powerpc64
+#
+#  # Trigger a rebuild of everything:
+#  OSXCROSS_TEST_REBUILD=0|1
+#
+#  # Project Versions:
+#  OSXCROSS_TEST_OPENSSL_VERSION=3.1.2
+#  OSXCROSS_TEST_WGET_VERSION=1.21.4
+#  OSXCROSS_TEST_CURL_VERSION=8.2.1
+################################################################################
+
+################################################################################
+# Determine the host prefix and compiler tools:
+################################################################################
+
+OSXCROSS_TEST_ARCH="${OSXCROSS_TEST_ARCH:-x86_64}"
+OSXCROSS_TEST_OSVERSION="unknown"
+OSXCROSS_TEST_XCRUNCC="$(xcrun -f cc 2>/dev/null)"
+OSXCROSS_TEST_XCRUNCC_VERSION_REGEX1=".*darwin([0-9])[-]cc$"
+OSXCROSS_TEST_XCRUNCC_VERSION_REGEX2=".*darwin([0-9]{2})[-]cc$"
+OSXCROSS_TEST_XCRUNCC_VERSION_REGEX3=".*darwin([0-9]{2}[.][0-9])[-]cc$"
+OSXCROSS_TEST_XCRUNCC_VERSION_REGEX4=".*darwin([0-9]{2}[.][0-9]{2})[-]cc$"
+if [[ $OSXCROSS_TEST_XCRUNCC =~ $OSXCROSS_TEST_XCRUNCC_VERSION_REGEX1 ]]
+then
+   OSXCROSS_TEST_OSVERSION="${BASH_REMATCH[1]}"
+elif [[ $OSXCROSS_TEST_XCRUNCC =~ $OSXCROSS_TEST_XCRUNCC_VERSION_REGEX2 ]]
+then
+   OSXCROSS_TEST_OSVERSION="${BASH_REMATCH[1]}"
+elif [[ $OSXCROSS_TEST_XCRUNCC =~ $OSXCROSS_TEST_XCRUNCC_VERSION_REGEX3 ]]
+then
+   OSXCROSS_TEST_OSVERSION="${BASH_REMATCH[1]}"
+elif [[ $OSXCROSS_TEST_XCRUNCC =~ $OSXCROSS_TEST_XCRUNCC_VERSION_REGEX4 ]]
+then
+   OSXCROSS_TEST_OSVERSION="${BASH_REMATCH[1]}"
+else
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Cannot Determine Toolchain OSVersion." 1>&2
+   exit 1
+fi
+
+OSXCROSS_TEST_HOST_PREFIX=\
+"${OSXCROSS_TEST_ARCH}-apple-darwin${OSXCROSS_TEST_OSVERSION}"
+OSXCROSS_TEST_TOOLCHAIN_CC="${OSXCROSS_TEST_HOST_PREFIX}-gcc"
+OSXCROSS_TEST_TOOLCHAIN_CXX="${OSXCROSS_TEST_HOST_PREFIX}-g++"
+OSXCROSS_TEST_TOOLCHAIN_FORTRAN="${OSXCROSS_TEST_HOST_PREFIX}-gfortran"
+OSXCROSS_TEST_TOOLCHAIN_AR="${OSXCROSS_TEST_HOST_PREFIX}-ar"
+OSXCROSS_TEST_TOOLCHAIN_RANLIB="${OSXCROSS_TEST_HOST_PREFIX}-ranlib"
+echo
+echo "======================================================================"
+echo " OS X Cross Autotool Configure Projects Test:"
+echo "======================================================================"
+echo " OSXCROSS_TEST_ARCH=${OSXCROSS_TEST_ARCH}"
+echo " OSXCROSS_TEST_HOST_PREFIX=${OSXCROSS_TEST_HOST_PREFIX}"
+echo " OSXCROSS_TEST_TOOLCHAIN_CC=${OSXCROSS_TEST_TOOLCHAIN_CC}"
+echo "======================================================================"
+OSXCROSS_TEST_TOOLCHAIN_CC_RUN="$(${OSXCROSS_TEST_TOOLCHAIN_CC} --version 2>&1)"
+if [ "${?}x" = "0x" ]
+then
+   echo "${OSXCROSS_TEST_TOOLCHAIN_CC_RUN}"
+else
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Failure running '${OSXCROSS_TEST_TOOLCHAIN_CC} --version'." 1>&2
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "${OSXCROSS_TEST_TOOLCHAIN_CC_RUN}" 1>&2
+   exit 1
+fi
+
+################################################################################
+# Create the test and stage directories:
+################################################################################
+
+OSXCROSS_TEST_DIR="$(pwd)/test/${OSXCROSS_TEST_ARCH}"
+OSXCROSS_TEST_STAGE_DIR="${OSXCROSS_TEST_DIR}/stage"
+mkdir -p "${OSXCROSS_TEST_DIR}"
+mkdir -p "${OSXCROSS_TEST_STAGE_DIR}"
+if [ ! -d "${OSXCROSS_TEST_STAGE_DIR}" ]
+then
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Cannot create Test Directory '${OSXCROSS_TEST_STAGE_DIR}'." 1>&2
+   exit 1
+fi
+
+echo
+echo "======================================================================"
+echo " OSXCROSS_TEST_DIR=${OSXCROSS_TEST_DIR}"
+echo " OSXCROSS_TEST_STAGE_DIR=${OSXCROSS_TEST_STAGE_DIR}"
+echo "======================================================================"
+echo
+
+################################################################################
+# Download the project sources:
+################################################################################
+
+OSXCROSS_TEST_OPENSSL_VERSION="${OSXCROSS_TEST_OPENSSL_VERSION:-3.1.2}"
+OSXCROSS_TEST_OPENSSL_PREFIX="openssl-${OSXCROSS_TEST_OPENSSL_VERSION}"
+OSXCROSS_TEST_OPENSSL_TAG="${OSXCROSS_TEST_OPENSSL_PREFIX}".TAG
+if [ ! -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_PREFIX}".tar.gz ]
+then
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_TAG}"
+   OSXCROSS_TEST_REBUILD=1
+   ( \
+      cd "${OSXCROSS_TEST_DIR}" \
+      && wget https://www.openssl.org/source/"${OSXCROSS_TEST_OPENSSL_PREFIX}".tar.gz \
+   )
+fi
+if [ -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_PREFIX}".tar.gz ]
+then
+   echo "Found: '${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_PREFIX}.tar.gz'."
+else
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Cannot retrieve OPENSSL Source." 1>&2
+   exit 1
+fi
+if [ ! -d "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_PREFIX}" ]
+then
+   echo "Uncompressing: '${OSXCROSS_TEST_OPENSSL_PREFIX}.tar.gz'."
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_TAG}"
+   OSXCROSS_TEST_REBUILD=1
+   ( \
+      cd "${OSXCROSS_TEST_DIR}" \
+      && tar xf "${OSXCROSS_TEST_OPENSSL_PREFIX}".tar.gz \
+   ) || {
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Failure Uncompressing '${OSXCROSS_TEST_OPENSSL_PREFIX}.tar.gz'." 1>&2
+      exit 1
+   }
+fi
+
+OSXCROSS_TEST_WGET_VERSION="${OSXCROSS_TEST_WGET_VERSION:-1.21.4}"
+OSXCROSS_TEST_WGET_PREFIX="wget-${OSXCROSS_TEST_WGET_VERSION}"
+OSXCROSS_TEST_WGET_TAG="${OSXCROSS_TEST_WGET_PREFIX}".TAG
+if [ ! -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_PREFIX}".tar.gz ]
+then
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}" \
+      && wget http://ftp.gnu.org/gnu/wget/"${OSXCROSS_TEST_WGET_PREFIX}".tar.gz \
+   )
+fi
+if [ -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_PREFIX}".tar.gz ]
+then
+   echo "Found: '${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_PREFIX}.tar.gz'."
+else
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Cannot retrieve WGET Source." 1>&2
+   exit 1
+fi
+if [ ! -d "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_PREFIX}" ]
+then
+   echo "Uncompressing: '${OSXCROSS_TEST_WGET_PREFIX}.tar.gz'."
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}" \
+      && tar xf "${OSXCROSS_TEST_WGET_PREFIX}".tar.gz \
+   ) || {
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Failure Uncompressing '${OSXCROSS_TEST_WGET_PREFIX}.tar.gz'." 1>&2
+      exit 1
+   }
+fi
+
+OSXCROSS_TEST_CURL_VERSION="${OSXCROSS_TEST_CURL_VERSION:-8.2.1}"
+OSXCROSS_TEST_CURL_PREFIX="curl-${OSXCROSS_TEST_CURL_VERSION}"
+OSXCROSS_TEST_CURL_TAG="${OSXCROSS_TEST_CURL_PREFIX}".TAG
+if [ ! -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_PREFIX}".tar.gz ]
+then
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}" \
+      && wget http://curl.haxx.se/download/"${OSXCROSS_TEST_CURL_PREFIX}".tar.gz \
+   )
+fi
+if [ -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_PREFIX}".tar.gz ]
+then
+   echo "Found: '${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_PREFIX}.tar.gz'."
+else
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Cannot retrieve CURL Source." 1>&2
+   exit 1
+fi
+if [ ! -d "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_PREFIX}" ]
+then
+   echo "Uncompressing: '${OSXCROSS_TEST_CURL_PREFIX}.tar.gz'."
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}" \
+      && tar xf "${OSXCROSS_TEST_CURL_PREFIX}".tar.gz \
+   ) || {
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Failure Uncompressing '${OSXCROSS_TEST_CURL_PREFIX}.tar.gz'." 1>&2
+      exit 1
+   }
+fi
+
+################################################################################
+# Build the projects
+################################################################################
+
+OSXCROSS_TEST_REBUILD="${OSXCROSS_TEST_REBUILD:-0}"
+
+OSXCROSS_TEST_OPENSSL_TARGET="unset"
+case "${OSXCROSS_TEST_ARCH}" in
+   aarch64|arm64|arm64e)
+      # NOTE: Maybe wont work for arm64e?
+      #  Perhaps 'BSD-generic64 no-asm' instead?
+      OSXCROSS_TEST_OPENSSL_TARGET="darwin64-arm64-cc"
+      ;;
+   x86_64|x86_64h)
+      # NOTE: Maybe wont work for x86_64h?
+      #  Perhaps 'BSD-generic64 no-asm' instead?
+      OSXCROSS_TEST_OPENSSL_TARGET="darwin64-x86_64-cc"
+      ;;
+   i[3456]86)
+      # Perhaps 'darwin-i386-cc i386 no-asm' instead?
+      OSXCROSS_TEST_OPENSSL_TARGET="darwin-i386-cc i386"
+      ;;
+   powerpc64)
+      OSXCROSS_TEST_OPENSSL_TARGET="darwin64-ppc-cc"
+      ;;
+   powerpc)
+      OSXCROSS_TEST_OPENSSL_TARGET="darwin-ppc-cc"
+      ;;
+   *)
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Cannot determine OPENSSL Target." 1>&2
+      exit 1
+      ;;
+esac
+
+if [ "${OSXCROSS_TEST_REBUILD}x" = "1x" \
+   -o ! -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_TAG}" \
+   -o ! -e "${OSXCROSS_TEST_STAGE_DIR}/bin/openssl" \
+   -o ! -e "${OSXCROSS_TEST_STAGE_DIR}/lib/libssl.dylib" ]
+then
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_TAG}"
+   OSXCROSS_TEST_REBUILD=1
+   ( \
+      cd "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_PREFIX}" \
+      && make clean 2>/dev/null \
+   )
+   ( \
+      cd "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_PREFIX}" \
+      && CC="${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+         CXX="${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+         AR="${OSXCROSS_TEST_TOOLCHAIN_AR}" \
+         RANLIB="${OSXCROSS_TEST_TOOLCHAIN_RANLIB}" \
+         ./Configure \
+         ${OSXCROSS_TEST_OPENSSL_TARGET} \
+         --prefix="${OSXCROSS_TEST_STAGE_DIR}" \
+         -latomic \
+      && make install \
+         CC="${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+         CXX="${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+         AR="${OSXCROSS_TEST_TOOLCHAIN_AR}" \
+         RANLIB="${OSXCROSS_TEST_TOOLCHAIN_RANLIB}" \
+      && touch "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_TAG}" \
+   ) || {
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Failure Building OPENSSL." 1>&2
+      exit 1
+   }
+fi
+if [ -e "${OSXCROSS_TEST_STAGE_DIR}/bin/openssl" \
+   -a -e "${OSXCROSS_TEST_STAGE_DIR}/lib/libssl.dylib" ]
+then
+   echo
+   echo "======================================================================"
+   echo " OPENSSL Build:"
+   echo "======================================================================"
+   file "${OSXCROSS_TEST_STAGE_DIR}/bin/openssl"
+   xcrun otool -arch all -hvL "${OSXCROSS_TEST_STAGE_DIR}/bin/openssl"
+   file "${OSXCROSS_TEST_STAGE_DIR}/lib/libssl.dylib"
+   xcrun otool -arch all -hvL "${OSXCROSS_TEST_STAGE_DIR}/lib/libssl.dylib"
+else
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_OPENSSL_TAG}"
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "OPENSSL Objects not Found." 1>&2
+   exit 1
+fi
+
+if [ "${OSXCROSS_TEST_REBUILD}x" = "1x" \
+   -o ! -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_TAG}" \
+   -o ! -e "${OSXCROSS_TEST_STAGE_DIR}/bin/wget" ]
+then
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_PREFIX}" \
+      && make clean 2>/dev/null \
+   )
+   ( \
+      cd "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_PREFIX}" \
+      && CC="${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+         CXX="${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+         ./configure \
+         ${OSXCROSS_TEST_WGET_TARGET} \
+         --host="${OSXCROSS_TEST_HOST_PREFIX}" \
+         --prefix="${OSXCROSS_TEST_STAGE_DIR}" \
+         --with-ssl=openssl \
+         --with-libssl-prefix="${OSXCROSS_TEST_STAGE_DIR}" \
+      && make install \
+      && touch "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_TAG}" \
+   ) || {
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Failure Building WGET." 1>&2
+      exit 1
+   }
+fi
+if [ -e "${OSXCROSS_TEST_STAGE_DIR}/bin/wget" ]
+then
+   echo
+   echo "======================================================================"
+   echo " WGET Build:"
+   echo "======================================================================"
+   file "${OSXCROSS_TEST_STAGE_DIR}/bin/wget"
+   xcrun otool -arch all -hvL "${OSXCROSS_TEST_STAGE_DIR}/bin/wget"
+else
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_WGET_TAG}"
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "WGET Objects not Found." 1>&2
+   exit 1
+fi
+
+if [ "${OSXCROSS_TEST_REBUILD}x" = "1x" \
+   -o ! -e "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_TAG}" \
+   -o ! -e "${OSXCROSS_TEST_STAGE_DIR}/bin/curl" ]
+then
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_TAG}"
+   ( \
+      cd "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_PREFIX}" \
+      && make clean 2>/dev/null \
+   )
+   ( \
+      cd "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_PREFIX}" \
+      && CC="${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+         CXX="${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+         LIBS="-framework Foundation -framework SystemConfiguration" \
+         ./configure \
+         ${OSXCROSS_TEST_CURL_TARGET} \
+         --host="${OSXCROSS_TEST_HOST_PREFIX}" \
+         --prefix="${OSXCROSS_TEST_STAGE_DIR}" \
+         --with-ssl="${OSXCROSS_TEST_STAGE_DIR}" \
+      && make install \
+      && touch "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_TAG}" \
+   ) || {
+      echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+         "Failure Building CURL." 1>&2
+      exit 1
+   }
+fi
+if [ -e "${OSXCROSS_TEST_STAGE_DIR}/bin/curl" ]
+then
+   echo
+   echo "======================================================================"
+   echo " CURL Build:"
+   echo "======================================================================"
+   file "${OSXCROSS_TEST_STAGE_DIR}/bin/curl"
+   xcrun otool -arch all -hvL "${OSXCROSS_TEST_STAGE_DIR}/bin/curl"
+else
+   rm -f "${OSXCROSS_TEST_DIR}/${OSXCROSS_TEST_CURL_TAG}"
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "CURL Objects not Found." 1>&2
+   exit 1
+fi

--- a/test_simple.sh
+++ b/test_simple.sh
@@ -1,0 +1,617 @@
+#!/usr/bin/env bash
+
+trap "exit 0" INT EXIT TERM HUP PIPE QUIT ILL KILL ABRT
+
+################################################################################
+# OS X Cross Build Test Some Simple, Perhaps Trivial C, C++, Fortran Programs:
+################################################################################
+# This script generates single source file programs in varioius languages and
+#  compiels them using the OS X Cross toolchain.
+################################################################################
+# NOTE: The OS X Cross stage directory target/bin is assumed to be at the
+#  beginning of the PATH.
+#
+# The following command must be able to locate the toolchain compilers:
+#
+#     xcrun -f cc
+################################################################################
+# The following environment variables effect the operation of this script:
+#
+#  # Set the test architecture to use:
+#  OSXCROSS_TEST_ARCH=aarch64|arm64
+#  OSXCROSS_TEST_ARCH=x86_64|x86_64h|i386
+#  OSXCROSS_TEST_ARCH=powerpc|powerpc64
+################################################################################
+
+################################################################################
+# Determine the host prefix and compiler tools:
+################################################################################
+
+OSXCROSS_TEST_ARCH="${OSXCROSS_TEST_ARCH:-x86_64}"
+OSXCROSS_TEST_OSVERSION="unknown"
+OSXCROSS_TEST_XCRUNCC="$(xcrun -f cc 2>/dev/null)"
+OSXCROSS_TEST_XCRUNCC_VERSION_REGEX1=".*darwin([0-9])[-]cc$"
+OSXCROSS_TEST_XCRUNCC_VERSION_REGEX2=".*darwin([0-9]{2})[-]cc$"
+OSXCROSS_TEST_XCRUNCC_VERSION_REGEX3=".*darwin([0-9]{2}[.][0-9])[-]cc$"
+OSXCROSS_TEST_XCRUNCC_VERSION_REGEX4=".*darwin([0-9]{2}[.][0-9]{2})[-]cc$"
+if [[ $OSXCROSS_TEST_XCRUNCC =~ $OSXCROSS_TEST_XCRUNCC_VERSION_REGEX1 ]]
+then
+   OSXCROSS_TEST_OSVERSION="${BASH_REMATCH[1]}"
+elif [[ $OSXCROSS_TEST_XCRUNCC =~ $OSXCROSS_TEST_XCRUNCC_VERSION_REGEX2 ]]
+then
+   OSXCROSS_TEST_OSVERSION="${BASH_REMATCH[1]}"
+elif [[ $OSXCROSS_TEST_XCRUNCC =~ $OSXCROSS_TEST_XCRUNCC_VERSION_REGEX3 ]]
+then
+   OSXCROSS_TEST_OSVERSION="${BASH_REMATCH[1]}"
+elif [[ $OSXCROSS_TEST_XCRUNCC =~ $OSXCROSS_TEST_XCRUNCC_VERSION_REGEX4 ]]
+then
+   OSXCROSS_TEST_OSVERSION="${BASH_REMATCH[1]}"
+else
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Cannot Determine Toolchain OSVersion." 1>&2
+   exit 1
+fi
+
+OSXCROSS_TEST_HOST_PREFIX=\
+"${OSXCROSS_TEST_ARCH}-apple-darwin${OSXCROSS_TEST_OSVERSION}"
+OSXCROSS_TEST_TOOLCHAIN_CC="${OSXCROSS_TEST_HOST_PREFIX}-gcc"
+OSXCROSS_TEST_TOOLCHAIN_CXX="${OSXCROSS_TEST_HOST_PREFIX}-g++"
+OSXCROSS_TEST_TOOLCHAIN_FORTRAN="${OSXCROSS_TEST_HOST_PREFIX}-gfortran"
+OSXCROSS_TEST_TOOLCHAIN_AR="${OSXCROSS_TEST_HOST_PREFIX}-ar"
+OSXCROSS_TEST_TOOLCHAIN_RANLIB="${OSXCROSS_TEST_HOST_PREFIX}-ranlib"
+echo
+echo "======================================================================"
+echo " OS X Cross Autotool Configure Projects Test:"
+echo "======================================================================"
+echo " OSXCROSS_TEST_ARCH=${OSXCROSS_TEST_ARCH}"
+echo " OSXCROSS_TEST_HOST_PREFIX=${OSXCROSS_TEST_HOST_PREFIX}"
+echo " OSXCROSS_TEST_TOOLCHAIN_CC=${OSXCROSS_TEST_TOOLCHAIN_CC}"
+echo "======================================================================"
+OSXCROSS_TEST_TOOLCHAIN_CC_RUN="$(${OSXCROSS_TEST_TOOLCHAIN_CC} --version 2>&1)"
+if [ "${?}x" = "0x" ]
+then
+   echo "${OSXCROSS_TEST_TOOLCHAIN_CC_RUN}"
+else
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Failure running '${OSXCROSS_TEST_TOOLCHAIN_CC} --version'." 1>&2
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "${OSXCROSS_TEST_TOOLCHAIN_CC_RUN}" 1>&2
+   exit 1
+fi
+
+################################################################################
+# Create the test and stage directories:
+################################################################################
+
+OSXCROSS_TEST_DIR="$(pwd)/test/${OSXCROSS_TEST_ARCH}"
+mkdir -p "${OSXCROSS_TEST_DIR}"
+if [ ! -d "${OSXCROSS_TEST_DIR}" ]
+then
+   echo "${BASH_SOURCE}:${LINENO}:ERROR:" \
+      "Cannot create Test Directory '${OSXCROSS_TEST_DIR}'." 1>&2
+   exit 1
+fi
+
+echo
+echo "======================================================================"
+echo " OSXCROSS_TEST_DIR=${OSXCROSS_TEST_DIR}"
+echo "======================================================================"
+
+################################################################################
+# FFPROG01: Fortran77 Helloworld Program:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " FFPROG01: Fortran77 Helloworld Program:"
+echo "======================================================================"
+
+FFPROG01_PREFIX="FFPROG01_f77_hello_world"
+FFPROG01_SOURCE="${FFPROG01_PREFIX}.f"
+FFPROG01_BINARY="${FFPROG01_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${FFPROG01_SOURCE}"
+c FFPROG01: Fortran77 Helloworld Program:
+      program hello_world
+      implicit none
+c
+      call hello
+      call hello
+
+      end
+
+      subroutine hello
+      implicit none
+      character*32 text
+c
+      text = 'Hello World!'
+      write (*,*) text
+c
+      end
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_FORTRAN}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      ./"${FFPROG01_SOURCE}" \
+      -o ./"${FFPROG01_BINARY}" \
+   && file ./"${FFPROG01_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${FFPROG01_BINARY}" \
+)
+
+################################################################################
+# FFPROG02: Fortran90 Helloworld Program:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " FFPROG02: Fortran90 Helloworld Program:"
+echo "======================================================================"
+
+FFPROG02_PREFIX="FFPROG02_f90_hello_world"
+FFPROG02_SOURCE="${FFPROG02_PREFIX}.f90"
+FFPROG02_BINARY="${FFPROG02_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${FFPROG02_SOURCE}"
+! FFPROG02: Fortran90 Helloworld Program:
+program main
+  implicit none
+  write ( *, '(a)' ) '  Hello, world!'
+  stop
+end
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_FORTRAN}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      ./"${FFPROG02_SOURCE}" \
+      -o ./"${FFPROG02_BINARY}" \
+   && file ./"${FFPROG02_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${FFPROG02_BINARY}" \
+)
+
+################################################################################
+# CCPROG01: C89 Helloworld Program:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " CCPROG01: C89 Helloworld Program:"
+echo "======================================================================"
+
+CCPROG01_PREFIX="CCPROG01_c89_hello_world"
+CCPROG01_SOURCE="${CCPROG01_PREFIX}.c"
+CCPROG01_BINARY="${CCPROG01_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${CCPROG01_SOURCE}"
+// CCPROG01: C89 Helloworld Program:
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(void)
+{
+   printf("Hello World!\n");
+
+   return EXIT_SUCCESS;
+}
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      ./"${CCPROG01_SOURCE}" \
+      -o ./"${CCPROG01_BINARY}" \
+   && file ./"${CCPROG01_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${CCPROG01_BINARY}" \
+)
+
+################################################################################
+# CCPROG02: C11 Program Using PThreads:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " CCPROG02: C11 Program Using PThreads:"
+echo "======================================================================"
+
+CCPROG02_PREFIX="CCPROG02_c11_phtreads"
+CCPROG02_SOURCE="${CCPROG02_PREFIX}.c"
+CCPROG02_BINARY="${CCPROG02_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${CCPROG02_SOURCE}"
+// CCPROG02: C11 Program Using PThreads:
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <unistd.h>
+
+static bool threadIsRunning = false;
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+static void * ThreadFunction(void * arg)
+{
+   pthread_mutex_lock(&mutex);
+   threadIsRunning = true;
+   pthread_cond_signal(&cond);
+   pthread_mutex_unlock(&mutex);
+   printf(
+         "In ThreadFunction(): arg='%s'.\n",
+         (arg != NULL) ? (const char *)arg : "");
+   return NULL;
+}
+
+int main(void)
+{
+   const char * hwString = "Hello World!";
+   int ptResult;
+   pthread_t pThread;
+
+   printf("In Main().\n");
+
+   pthread_mutex_lock(&mutex);
+
+   ptResult = pthread_create(&pThread, NULL, &ThreadFunction, (void *)hwString);
+   if (ptResult != 0)
+   {
+      errno = ptResult;
+      perror("Failure: Creating Thread.");
+      exit(EXIT_FAILURE);
+   }
+
+   while (threadIsRunning == false)
+   {
+      pthread_cond_wait(&cond, &mutex);
+   }
+
+   pthread_mutex_unlock(&mutex);
+
+   ptResult = pthread_join(pThread, NULL);
+   if (ptResult != 0)
+   {
+      errno = ptResult;
+      perror("Failure: Joining Thread.");
+      exit(EXIT_FAILURE);
+   }
+
+   printf("Back In Main().\n");
+
+   return EXIT_SUCCESS;
+}
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_CC}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      -std=c11 \
+      ./"${CCPROG02_SOURCE}" \
+      -o ./"${CCPROG02_BINARY}" \
+   && file ./"${CCPROG02_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${CCPROG02_BINARY}" \
+)
+
+################################################################################
+# CXPROG01: C++03 Helloworld Program:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " CXPROG01: C++03 Helloworld Program:"
+echo "======================================================================"
+
+CXPROG01_PREFIX="CXPROG01_c++04_hello_world"
+CXPROG01_SOURCE="${CXPROG01_PREFIX}.c"
+CXPROG01_BINARY="${CXPROG01_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG01_SOURCE}"
+// CXPROG01: C++03 Helloworld Program:
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main()
+{
+   const ::std::string hwString("Hello World!");
+
+   ::std::cout << hwString << ::std::endl;
+
+   return 0;
+}
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      -std=c++98 \
+      ./"${CXPROG01_SOURCE}" \
+      -o ./"${CXPROG01_BINARY}" \
+   && file ./"${CXPROG01_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${CXPROG01_BINARY}" \
+)
+
+################################################################################
+# CXPROG02: C++11 Program Using ::std::thread:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " CXPROG02: C++11 Program Using ::std::thread:"
+echo "======================================================================"
+
+CXPROG02_PREFIX="CXPROG02_c++11_std_thread"
+CXPROG02_SOURCE="${CXPROG02_PREFIX}.c"
+CXPROG02_BINARY="${CXPROG02_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG02_SOURCE}"
+// CXPROG02: C++11 Program Using ::std::thread:
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+#include <condition_variable>
+#include <mutex>
+
+static bool threadIsRunning(false);
+static ::std::condition_variable cv;
+static ::std::mutex cvm;
+
+static void ThreadFunction()
+{
+   cvm.lock();
+   threadIsRunning = true;
+   cv.notify_one();
+   cvm.unlock();
+
+   ::std::cout << "In ThreadFunction():" << ::std::endl;
+}
+
+int main()
+{
+   ::std::unique_lock< ::std::mutex> cvlk(cvm);
+
+   ::std::cout << "In Main():" << ::std::endl;
+
+   ::std::thread th(&ThreadFunction);
+
+   while (!threadIsRunning)
+   {
+      cv.wait(cvlk);
+   }
+
+   cvlk.unlock();
+
+   th.join();
+
+   ::std::cout << "Back In Main():" << ::std::endl;
+
+   return EXIT_SUCCESS;
+}
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      -std=c++11 \
+      ./"${CXPROG02_SOURCE}" \
+      -o ./"${CXPROG02_BINARY}" \
+   && file ./"${CXPROG02_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${CXPROG02_BINARY}" \
+)
+
+################################################################################
+# CXPROG03: C++11 Program Using Lamdas:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " CXPROG03: C++11 Program Using ::std::thread:"
+echo "======================================================================"
+
+CXPROG03_PREFIX="CXPROG03_c++11_lamdas"
+CXPROG03_SOURCE="${CXPROG03_PREFIX}.c"
+CXPROG03_BINARY="${CXPROG03_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG03_SOURCE}"
+// CXPROG03: C++11 Program Using ::std::thread:
+#include <cstdlib>
+#include <iostream>
+
+int main()
+{
+   ::std::cout << [](int m, int n) { return m + n;} (2,4) << ::std::endl;
+
+   return EXIT_SUCCESS;
+}
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      -std=c++11 \
+      ./"${CXPROG03_SOURCE}" \
+      -o ./"${CXPROG03_BINARY}" \
+   && file ./"${CXPROG03_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${CXPROG03_BINARY}" \
+)
+
+################################################################################
+# CXPROG04: C++14 Program Using Generic Lamdas:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " CXPROG04: C++14 Program Using Generic Lamdas:"
+echo "======================================================================"
+
+CXPROG04_PREFIX="CXPROG04_c++14_generic_lamdas"
+CXPROG04_SOURCE="${CXPROG04_PREFIX}.c"
+CXPROG04_BINARY="${CXPROG04_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG04_SOURCE}"
+// CXPROG04: C++14 Program Using Generic Lamdas:
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <string>
+#include <numeric>
+
+int main()
+{
+  ::std::vector<int> ivec = { 1, 2, 3, 4};
+  ::std::vector<std::string> svec = { "red",
+                                    "green",
+                                    "blue" };
+  auto adder  = [](auto op1, auto op2){ return op1 + op2; };
+  ::std::cout << "int result : "
+            << ::std::accumulate(ivec.begin(),
+                               ivec.end(),
+                               0,
+                               adder )
+            << "\n";
+  ::std::cout << "string result : "
+            << ::std::accumulate(svec.begin(),
+                               svec.end(),
+                               ::std::string(""),
+                               adder )
+            << "\n";
+
+   return EXIT_SUCCESS;
+}
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      -std=c++14 \
+      ./"${CXPROG04_SOURCE}" \
+      -o ./"${CXPROG04_BINARY}" \
+   && file ./"${CXPROG04_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${CXPROG04_BINARY}" \
+)
+
+################################################################################
+# CXPROG05: C++14 Program Using ::std::shared_timed_mutex:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " CXPROG05: C++14 Program Using ::std::shared_timed_mutex:"
+echo "======================================================================"
+
+CXPROG05_PREFIX="CXPROG05_c++14_using_std_shared_timed_mutex"
+CXPROG05_SOURCE="${CXPROG05_PREFIX}.c"
+CXPROG05_BINARY="${CXPROG05_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG05_SOURCE}"
+// CXPROG05: C++14 Program Using ::std::shared_timed_mutex:
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <list>
+#include <atomic>
+#include <mutex>
+#include <shared_mutex>
+#include <thread>
+
+#define MAIN_WAIT_MILLISECONDS 220
+
+static void useSTLSharedTimedMutex()
+{
+   std::shared_timed_mutex shared_mtx_lock;
+
+   std::vector<std::thread> readThreads;
+   std::vector<std::thread> writeThreads;
+
+   std::list<int> data = { 0 };
+   volatile bool exit = false;
+
+   std::atomic<int> readProcessedCnt(0);
+   std::atomic<int> writeProcessedCnt(0);
+
+   for (unsigned int i = 0; i < std::thread::hardware_concurrency(); i++)
+   {
+
+       readThreads.push_back(std::thread([&data, &exit, &shared_mtx_lock, &readProcessedCnt]() {
+           std::list<int> mydata;
+           int localProcessCnt = 0;
+
+           while (true)
+           {
+               shared_mtx_lock.lock_shared();
+
+               mydata.push_back(data.back());
+               ++localProcessCnt;
+
+               shared_mtx_lock.unlock_shared();
+
+               if (exit)
+                   break;
+           }
+
+           std::atomic_fetch_add(&readProcessedCnt, localProcessCnt);
+
+       }));
+
+       writeThreads.push_back(std::thread([&data, &exit, &shared_mtx_lock, &writeProcessedCnt]() {
+
+           int localProcessCnt = 0;
+
+           while (true)
+           {
+               shared_mtx_lock.lock();
+
+               data.push_back(rand() % 100);
+               ++localProcessCnt;
+
+               shared_mtx_lock.unlock();
+
+               if (exit)
+                   break;
+           }
+
+           std::atomic_fetch_add(&writeProcessedCnt, localProcessCnt);
+
+       }));
+   }
+
+   std::this_thread::sleep_for(std::chrono::milliseconds(MAIN_WAIT_MILLISECONDS));
+   exit = true;
+
+   for (auto &r : readThreads)
+       r.join();
+
+   for (auto &w : writeThreads)
+       w.join();
+
+   std::cout << "STLSharedTimedMutex READ :      " << readProcessedCnt << std::endl;
+   std::cout << "STLSharedTimedMutex WRITE :     " << writeProcessedCnt << std::endl;
+   std::cout << "TOTAL READ&WRITE :              " << readProcessedCnt + writeProcessedCnt << std::endl << std::endl;
+}
+
+int main()
+{
+   useSTLSharedTimedMutex();
+
+   return EXIT_SUCCESS;
+}
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      -std=c++14 \
+      ./"${CXPROG05_SOURCE}" \
+      -o ./"${CXPROG05_BINARY}" \
+   && file ./"${CXPROG05_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${CXPROG05_BINARY}" \
+)

--- a/test_simple.sh
+++ b/test_simple.sh
@@ -61,7 +61,7 @@ OSXCROSS_TEST_TOOLCHAIN_AR="${OSXCROSS_TEST_HOST_PREFIX}-ar"
 OSXCROSS_TEST_TOOLCHAIN_RANLIB="${OSXCROSS_TEST_HOST_PREFIX}-ranlib"
 echo
 echo "======================================================================"
-echo " OS X Cross Autotool Configure Projects Test:"
+echo " OS X Cross Test:"
 echo "======================================================================"
 echo " OSXCROSS_TEST_ARCH=${OSXCROSS_TEST_ARCH}"
 echo " OSXCROSS_TEST_HOST_PREFIX=${OSXCROSS_TEST_HOST_PREFIX}"
@@ -305,7 +305,7 @@ echo "======================================================================"
 echo " CXPROG01: C++03 Helloworld Program:"
 echo "======================================================================"
 
-CXPROG01_PREFIX="CXPROG01_c++04_hello_world"
+CXPROG01_PREFIX="CXPROG01_c++03_hello_world"
 CXPROG01_SOURCE="${CXPROG01_PREFIX}.c"
 CXPROG01_BINARY="${CXPROG01_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
 cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG01_SOURCE}"
@@ -320,7 +320,7 @@ int main()
 
    ::std::cout << hwString << ::std::endl;
 
-   return 0;
+   return EXIT_SUCCESS;
 }
 EOF
 
@@ -329,7 +329,7 @@ EOF
    && "${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
       -O6 -Wall -g \
       -static-libgcc \
-      -std=c++98 \
+      -std=c++03 \
       ./"${CXPROG01_SOURCE}" \
       -o ./"${CXPROG01_BINARY}" \
    && file ./"${CXPROG01_BINARY}" \
@@ -411,14 +411,14 @@ EOF
 
 echo
 echo "======================================================================"
-echo " CXPROG03: C++11 Program Using ::std::thread:"
+echo " CXPROG03: C++11 Program Using Lamdas:"
 echo "======================================================================"
 
 CXPROG03_PREFIX="CXPROG03_c++11_lamdas"
 CXPROG03_SOURCE="${CXPROG03_PREFIX}.c"
 CXPROG03_BINARY="${CXPROG03_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
 cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG03_SOURCE}"
-// CXPROG03: C++11 Program Using ::std::thread:
+// CXPROG03: C++11 Program Using Lamdas:
 #include <cstdlib>
 #include <iostream>
 

--- a/test_simple.sh
+++ b/test_simple.sh
@@ -306,7 +306,7 @@ echo " CXPROG01: C++03 Helloworld Program:"
 echo "======================================================================"
 
 CXPROG01_PREFIX="CXPROG01_c++03_hello_world"
-CXPROG01_SOURCE="${CXPROG01_PREFIX}.c"
+CXPROG01_SOURCE="${CXPROG01_PREFIX}.cpp"
 CXPROG01_BINARY="${CXPROG01_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
 cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG01_SOURCE}"
 // CXPROG01: C++03 Helloworld Program:
@@ -346,7 +346,7 @@ echo " CXPROG02: C++11 Program Using ::std::thread:"
 echo "======================================================================"
 
 CXPROG02_PREFIX="CXPROG02_c++11_std_thread"
-CXPROG02_SOURCE="${CXPROG02_PREFIX}.c"
+CXPROG02_SOURCE="${CXPROG02_PREFIX}.cpp"
 CXPROG02_BINARY="${CXPROG02_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
 cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG02_SOURCE}"
 // CXPROG02: C++11 Program Using ::std::thread:
@@ -415,7 +415,7 @@ echo " CXPROG03: C++11 Program Using Lamdas:"
 echo "======================================================================"
 
 CXPROG03_PREFIX="CXPROG03_c++11_lamdas"
-CXPROG03_SOURCE="${CXPROG03_PREFIX}.c"
+CXPROG03_SOURCE="${CXPROG03_PREFIX}.cpp"
 CXPROG03_BINARY="${CXPROG03_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
 cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG03_SOURCE}"
 // CXPROG03: C++11 Program Using Lamdas:
@@ -452,7 +452,7 @@ echo " CXPROG04: C++14 Program Using Generic Lamdas:"
 echo "======================================================================"
 
 CXPROG04_PREFIX="CXPROG04_c++14_generic_lamdas"
-CXPROG04_SOURCE="${CXPROG04_PREFIX}.c"
+CXPROG04_SOURCE="${CXPROG04_PREFIX}.cpp"
 CXPROG04_BINARY="${CXPROG04_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
 cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG04_SOURCE}"
 // CXPROG04: C++14 Program Using Generic Lamdas:
@@ -508,7 +508,7 @@ echo " CXPROG05: C++14 Program Using ::std::shared_timed_mutex:"
 echo "======================================================================"
 
 CXPROG05_PREFIX="CXPROG05_c++14_using_std_shared_timed_mutex"
-CXPROG05_SOURCE="${CXPROG05_PREFIX}.c"
+CXPROG05_SOURCE="${CXPROG05_PREFIX}.cpp"
 CXPROG05_BINARY="${CXPROG05_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
 cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG05_SOURCE}"
 // CXPROG05: C++14 Program Using ::std::shared_timed_mutex:

--- a/test_simple.sh
+++ b/test_simple.sh
@@ -116,9 +116,9 @@ c FFPROG01: Fortran77 Helloworld Program:
 c
       call hello
       call hello
-
+c
       end
-
+c
       subroutine hello
       implicit none
       character*32 text
@@ -614,4 +614,122 @@ EOF
       -o ./"${CXPROG05_BINARY}" \
    && file ./"${CXPROG05_BINARY}" \
    && xcrun otool -arch all -hvL ./"${CXPROG05_BINARY}" \
+)
+
+################################################################################
+# CXPROG06: C++17 Program Using ::std::string_view:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " CXPROG06: C++17 Program Using ::std::string_view:"
+echo "======================================================================"
+
+CXPROG06_PREFIX="CXPROG06_c++17_std_string_view"
+CXPROG06_SOURCE="${CXPROG06_PREFIX}.cpp"
+CXPROG06_BINARY="${CXPROG06_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG06_SOURCE}"
+// CXPROG06: C++17 Program Using ::std::string_view:
+#include <cstdlib>
+#include <iostream>
+#include <string_view>
+
+int main()
+{
+   const ::std::string_view str_1{ "Hello World!" };
+   const ::std::string_view str_2{ str_1 };
+   const ::std::string_view str_3{ str_2 };
+   std::cout << str_1 << '\n' << str_2 << '\n' << str_3 << '\n';
+   return EXIT_SUCCESS;
+}
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      -std=c++17 \
+      ./"${CXPROG06_SOURCE}" \
+      -o ./"${CXPROG06_BINARY}" \
+   && file ./"${CXPROG06_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${CXPROG06_BINARY}" \
+)
+
+################################################################################
+# CXPROG07: C++17 Program Using ::std::shared_mutex:
+################################################################################
+
+echo
+echo "======================================================================"
+echo " CXPROG07: C++17 Program Using ::std::shared_mutex:"
+echo "======================================================================"
+
+CXPROG07_PREFIX="CXPROG07_c++17_std_string_view"
+CXPROG07_SOURCE="${CXPROG07_PREFIX}.cpp"
+CXPROG07_BINARY="${CXPROG07_PREFIX}.bin.${OSXCROSS_TEST_ARCH}"
+cat <<EOF >"${OSXCROSS_TEST_DIR}/${CXPROG07_SOURCE}"
+// CXPROG07: C++17 Program Using ::std::shared_mutex:
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+#include <shared_mutex>
+
+static int value = 0;
+static std::shared_mutex mutex;
+
+// Reads the value and sets v to that value
+void readValue(int& v)
+{
+   mutex.lock_shared();
+   // Simulate some latency
+   std::this_thread::sleep_for(std::chrono::seconds(1));
+   v = value;
+   mutex.unlock_shared();
+}
+
+// Sets value to v
+void setValue(int v)
+{
+   mutex.lock();
+   // Simulate some latency
+   std::this_thread::sleep_for(std::chrono::seconds(1));
+   value = v;
+   mutex.unlock();
+}
+
+int main()
+{
+   int read1;
+   int read2;
+   int read3;
+   std::thread t1(readValue, std::ref(read1));
+   std::thread t2(readValue, std::ref(read2));
+   std::thread t3(readValue, std::ref(read3));
+   std::thread t4(setValue, 1);
+
+   t1.join();
+   t2.join();
+   t3.join();
+   t4.join();
+
+   std::cout << read1 << "\n";
+   std::cout << read2 << "\n";
+   std::cout << read3 << "\n";
+   std::cout << value << "\n";
+
+   return EXIT_SUCCESS;
+}
+EOF
+
+(
+   cd "${OSXCROSS_TEST_DIR}/" \
+   && "${OSXCROSS_TEST_TOOLCHAIN_CXX}" \
+      -O6 -Wall -g \
+      -static-libgcc \
+      -std=c++17 \
+      ./"${CXPROG07_SOURCE}" \
+      -o ./"${CXPROG07_BINARY}" \
+   && file ./"${CXPROG07_BINARY}" \
+   && xcrun otool -arch all -hvL ./"${CXPROG07_BINARY}" \
 )

--- a/test_simple.sh
+++ b/test_simple.sh
@@ -139,6 +139,11 @@ EOF
    && file ./"${FFPROG01_BINARY}" \
    && xcrun otool -arch all -hvL ./"${FFPROG01_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${FFPROG01_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${FFPROG01_BINARY}" 2>/dev/null
+fi
 
 ################################################################################
 # FFPROG02: Fortran90 Helloworld Program:
@@ -171,6 +176,11 @@ EOF
    && file ./"${FFPROG02_BINARY}" \
    && xcrun otool -arch all -hvL ./"${FFPROG02_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${FFPROG02_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${FFPROG02_BINARY}" 2>/dev/null
+fi
 
 ################################################################################
 # CCPROG01: C89 Helloworld Program:
@@ -207,6 +217,11 @@ EOF
    && file ./"${CCPROG01_BINARY}" \
    && xcrun otool -arch all -hvL ./"${CCPROG01_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${CCPROG01_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${CCPROG01_BINARY}" 2>/dev/null
+fi
 
 ################################################################################
 # CCPROG02: C11 Program Using PThreads:
@@ -295,6 +310,11 @@ EOF
    && file ./"${CCPROG02_BINARY}" \
    && xcrun otool -arch all -hvL ./"${CCPROG02_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${CCPROG02_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${CCPROG02_BINARY}" 2>/dev/null
+fi
 
 ################################################################################
 # CXPROG01: C++03 Helloworld Program:
@@ -335,6 +355,11 @@ EOF
    && file ./"${CXPROG01_BINARY}" \
    && xcrun otool -arch all -hvL ./"${CXPROG01_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${CXPROG01_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${CXPROG01_BINARY}" 2>/dev/null
+fi
 
 ################################################################################
 # CXPROG02: C++11 Program Using ::std::thread:
@@ -404,6 +429,11 @@ EOF
    && file ./"${CXPROG02_BINARY}" \
    && xcrun otool -arch all -hvL ./"${CXPROG02_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${CXPROG02_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${CXPROG02_BINARY}" 2>/dev/null
+fi
 
 ################################################################################
 # CXPROG03: C++11 Program Using Lamdas:
@@ -441,6 +471,11 @@ EOF
    && file ./"${CXPROG03_BINARY}" \
    && xcrun otool -arch all -hvL ./"${CXPROG03_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${CXPROG03_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${CXPROG03_BINARY}" 2>/dev/null
+fi
 
 ################################################################################
 # CXPROG04: C++14 Program Using Generic Lamdas:
@@ -497,6 +532,11 @@ EOF
    && file ./"${CXPROG04_BINARY}" \
    && xcrun otool -arch all -hvL ./"${CXPROG04_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${CXPROG04_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${CXPROG04_BINARY}" 2>/dev/null
+fi
 
 ################################################################################
 # CXPROG05: C++14 Program Using ::std::shared_timed_mutex:
@@ -615,6 +655,11 @@ EOF
    && file ./"${CXPROG05_BINARY}" \
    && xcrun otool -arch all -hvL ./"${CXPROG05_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${CXPROG05_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${CXPROG05_BINARY}" 2>/dev/null
+fi
 
 ################################################################################
 # CXPROG06: C++17 Program Using ::std::string_view:
@@ -655,6 +700,11 @@ EOF
    && file ./"${CXPROG06_BINARY}" \
    && xcrun otool -arch all -hvL ./"${CXPROG06_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${CXPROG06_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${CXPROG06_BINARY}" 2>/dev/null
+fi
 
 ################################################################################
 # CXPROG07: C++17 Program Using ::std::shared_mutex:
@@ -733,3 +783,8 @@ EOF
    && file ./"${CXPROG07_BINARY}" \
    && xcrun otool -arch all -hvL ./"${CXPROG07_BINARY}" \
 )
+if [ -x "${OSXCROSS_TEST_DIR}/${CXPROG07_BINARY}" ]
+then
+   xcrun vtool -show-build \
+      "${OSXCROSS_TEST_DIR}/${CXPROG07_BINARY}" 2>/dev/null
+fi


### PR DESCRIPTION
Some minor changes to the build_gcc.sh script to get mainline GCC-5.5.0 working with the ppc-test branch.

Also documentation describing how I created a usable toolchain that seems to be working flawlessly. It can build C and C++ up C++14 code that runs on my iBook G4.

The toolchain also builds for PowerPC64, although I am unable to test, since I dont have access to a PowerPC64 Mac at this time.

I have provided a couple of scripts:

test_autotools.sh: Builds the latest version of OpenSSL, WGet, and CURL and they are running and working on my iBook G4.

test_simple.sh: Builds some F77, F90, C89, C11, C++03, C++11, and C++14 programs that run on my iBook G4. Well except for the Fortran programs because the OS X Cross build did not stage the gfortran compiler for PPC32.

Please consider merging this into the ppc-test branch. Hopefully it will help others that need to create a toolchain that targets MacOS powerpc with a newer toolchain and newer C++ standards.