### PR TITLE
Fix getExecutablePath() that causes SDK path detection failure in the…

### DIFF
--- a/wrapper/tools.cpp
+++ b/wrapper/tools.cpp
@@ -135,8 +135,9 @@ char *getExecutablePath(char *buf, size_t len) {
     l = 0;
   delete[] argv;
 #else
-  ssize_t l = readlink("/proc/self/exe", buf, len);
+  ssize_t l = readlink("/proc/self/exe", buf, len - 1);
   assert(l > 0 && "/proc not mounted?");
+  if (l > 0) buf[l] = '\0';
 #endif
   if (l <= 0)
     return nullptr;


### PR DESCRIPTION
… wrapper. This is ported from master. Otherwise the wrapper can use random data in memory for a byte in the SDK PATH detection logic and can cause the wrapper to fail.