### PR TITLE
fix: don't overwrite CMAKE_FIND_ROOT_PATH

### DIFF
--- a/tools/toolchain.cmake
+++ b/tools/toolchain.cmake
@@ -26,6 +26,7 @@ set(CMAKE_CXX_COMPILER "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-clang++")
 
 # where is the target environment
 set(CMAKE_FIND_ROOT_PATH
+  "${CMAKE_FIND_ROOT_PATH}"
   "${OSXCROSS_SDK}"
   "${OSXCROSS_TARGET_DIR}/macports/pkgs/opt/local")
 


### PR DESCRIPTION
This enables the use of -DCMAKE_FIND_ROOT_PATH=/additional/root/path.

This is useful when building with dependencies that are built separately and is available in different root path.

This probably also solves: https://github.com/tpoechtrager/osxcross/issues/241

There is discussion about the use case here: https://discourse.cmake.org/t/cmake-find-root-path-and-toolchain-files/3294/3
