### PR TITLE
support any_any macports packages

### DIFF
--- a/tools/osxcross-macports
+++ b/tools/osxcross-macports
@@ -316,10 +316,18 @@ getPkgUrl()
           uniq | tail -n1)
   fi
   if [ -z "$pkg" ]; then
+    pkg=$(echo "$pkgs" | \
+          grep "$pkgname-$pkgversion" | grep "any_any.noarch" | \
+          uniq | tail -n1)
+  fi
+  if [ -z "$pkg" ]; then
     pkg=$(echo "$pkgs" | grep $OSXVERSION | grep $ARCH | uniq | tail -n1)
   fi
   if [ -z "$pkg" ]; then
     pkg=$(echo "$pkgs" | grep $OSXVERSION | grep "noarch" | uniq | tail -n1)
+  fi
+  if [ -z "$pkg" ]; then
+    pkg=$(echo "$pkgs" | grep "any_any.noarch" | uniq | tail -n1)
   fi
 
   verboseMsg " selected: $pkg"


### PR DESCRIPTION
Currently `osxcross-macports` is unable to install `curl-ca-bundle` since is only checks for OSXVERSION and those packages are now marked `any_any` instead of specific OSX version. This should allow them to be selected now.