### PR TITLE
Use `cd` instead of `cpio -D` to support older versions of `cpio`

### DIFF
--- a/tools/gen_sdk_package_tools_dmg.sh
+++ b/tools/gen_sdk_package_tools_dmg.sh
@@ -60,7 +60,7 @@ echo "Processing packages ..."
 mkdir "$TMP_DIR/out"
 for PKG in $TMP_DIR/pkg_data/*.pkg; do
   LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TARGET_DIR/lib \
-    verbose_cmd "$TARGET_DIR/SDK/tools/bin/pbzx -n \"$PKG/Payload\" | cpio -i -D $TMP_DIR/out"
+    verbose_cmd "$TARGET_DIR/SDK/tools/bin/pbzx -n \"$PKG/Payload\" | (cd $TMP_DIR/out && cpio -i)"
 done
 
 


### PR DESCRIPTION
This PR removes the usage of `cpio -D` in order to support older versions. Ubuntu 16.04 has `cpio` version 2.11, which does not contain the `-D` argument.