### PR TITLE
add bzip2-devel as a Linux dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ This method may require up to 45 GB of free disk space.
 An SSD is recommended for this method.
 
 1. Download Xcode like described in 'Packaging the SDK on macOS'
-2. Install `clang`, `make`, `libssl-devel`, `lzma-devel` and `libxml2-devel`
+2. Install the following packages:\
+   On Debian/Ubuntu: `apt install clang make libssl-dev libbz2-dev lzma-dev libxml2-dev`\
+   On Fedora: `dnf install clang make openssl-devel bzip2-devel xz-devel libxml2-devel`
 3. Run `./tools/gen_sdk_package_pbzx.sh <xcode>.xip`
 4. Copy or move the SDK into the tarballs/ directory
 


### PR DESCRIPTION
As mentioned in #118, the libbz2-dev package (bzip2-devel on Fedora) must be installed or else xar will be built without bzip2 support and will fail at a later step. This PR updates the "Packing the SDK on Linux - Method 1" section in the README so that new users know to install this package. It also adds separate instructions for Debian and Fedora, since the package names differ.