### PR TITLE
fix: gen_sdk_package.sh

### DIFF
--- a/tools/gen_sdk_package.sh
+++ b/tools/gen_sdk_package.sh
@@ -191,8 +191,11 @@ else
 
 fi
 
-SDKS=$(ls | grep -E "^MacOSX14.*|^MacOSX13.*|^MacOSX12.*|^MacOSX11.*|^MacOSX10.*" | grep -v "Patch")
 
+SDKS=$(for sdk in $(ls | grep -E "^MacOSX14.*|^MacOSX13.*|^MacOSX12.*|^MacOSX11.*|^MacOSX10.*" | grep -v "Patch"); do 
+  [ -e "$sdk" ] || continue;  # Skip if the file doesn't exist
+  echo "$(rreadlink "$sdk") $sdk"; 
+done | awk '!seen[$1]++' | awk '{print $2}')
 if [ -z "$SDKS" ]; then
   echo "No SDK found" 1>&2
   exit 1


### PR DESCRIPTION
[tools/gen_sdk_package.sh](https://github.com/teocns/osxcross/blob/master/tools/gen_sdk_package.sh) redundantly packages symlinks pointing to the same SDK, resulting in duplicates
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs $ ls -la
.
..
MacOSX.sdk
MacOSX13.3.sdk -> MacOSX.sdk
MacOSX13.sdk -> MacOSX.sdk

$ ./gen_sdk_package.sh
found Xcode: /Applications/Xcode.app
packaging MacOSX13.3 SDK (this may take several minutes) ...
packaging MacOSX13 SDK (this may take several minutes) ...
```



In this case `MacOS13` and `MacOS13.3` are symlinks that point to the same SDK. The script should be able to detect this and not package the same SDK twice.

The implemented change filters out SDK symlink entries that reference the same SDK, retaining the one with the verbose-most version (minor)