### PR TITLE
tools/osxcross-macports: add support for "any" darwin version

### DIFF
--- a/tools/osxcross-macports
+++ b/tools/osxcross-macports
@@ -321,6 +321,9 @@ getPkgUrl()
   if [ -z "$pkg" ]; then
     pkg=$(echo "$pkgs" | grep $OSXVERSION | grep "noarch" | uniq | tail -n1)
   fi
+  if [ -z "$pkg" ]; then
+    pkg=$(echo "$pkgs" | grep "any" | grep "noarch" | uniq | tail -n1)
+  fi
 
   verboseMsg " selected: $pkg"
 


### PR DESCRIPTION
like packages: https://packages.macports.org/xorg-xorgproto/


As now **omp** is unable to installs **xorg-xorgproto** as it is marked "`darwin_any.noarch`" and prev check
`$OSXVERSION | grep "noarch"`
never match those kind of packages.

This solve also: https://github.com/tpoechtrager/osxcross/issues/399