### PR TITLE
Fix misnamed "packet manager" to "package manager"  in docs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -150,7 +150,7 @@ Changed:
 Added:
  * binutils / gdb build script
  * OSXCROSS_GCC_NO_STATIC_RUNTIME option (env)
- * osxcross-macports: A minimalistic macports packet manager
+ * osxcross-macports: A minimalistic macports package manager
 
 /******************************* v0.8 *******************************/
 

--- a/README.MACPORTS.md
+++ b/README.MACPORTS.md
@@ -1,6 +1,6 @@
 ## OSXCROSS-MACPORTS ##
 
-`osxcross-macports` is a small "packet manager" for 16.000+ binary MacPorts packages.
+`osxcross-macports` is a small "package manager" for 16.000+ binary MacPorts packages.
 
 Packages are installed to `target/macports/pkgs`.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Note: The "compiler-rt" library can be needed to link code that uses the
 Basically everything you can build on macOS with clang/gcc should build with
 this cross toolchain as well.
 
-### PACKET MANAGERS ###
+### PACKAGE MANAGERS ###
 
-OSXCross comes with a minimalistic MacPorts Packet Manager.
+OSXCross comes with a minimalistic MacPorts Package Manager.
 See [README.MACPORTS](README.MACPORTS.md) for more.
 
 ### INSTALLATION: ###

--- a/tools/osxcross-macports
+++ b/tools/osxcross-macports
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ##
-## A minimalistic MacPorts Packet Manager for OSXCross,
+## A minimalistic MacPorts Package Manager for OSXCross,
 ## based on: https://github.com/maci0/pmmacports.
 ## Please see README.MACPORTS for more.
 ## License: GPLv2.


### PR DESCRIPTION
I've made the same mistake, it's an easy one to do. Thanks for the project, it's been a life saver!