### PR TITLE
osxcross-macports: Properly support "any" version packages.

### DIFF
--- a/tools/osxcross-macports
+++ b/tools/osxcross-macports
@@ -324,6 +324,9 @@ getPkgUrl()
     pkg=$(echo "$pkgs" | grep $OSXVERSION | grep "noarch" | uniq | tail -n1)
   fi
   if [ -z "$pkg" ]; then
+    pkg=$(echo "$pkgs" | grep "any" | grep $ARCH | uniq | tail -n1)
+  fi
+  if [ -z "$pkg" ]; then
     pkg=$(echo "$pkgs" | grep "any" | grep "noarch" | uniq | tail -n1)
   fi
 


### PR DESCRIPTION
This extends https://github.com/tpoechtrager/osxcross/pull/409 by supporting "any" packages that also have an architecture attributed to them, not just "noarch" packages.

Currently if you attempt to install any package that requires libgcc (like OpenBLAS for example), the macports wrapper script will fail to resolve to a correct package despite there being one.