### PR TITLE
Remove hardcoded use of make when building llvm-dsymutil.

### DIFF
--- a/build_llvm_dsymutil.sh
+++ b/build_llvm_dsymutil.sh
@@ -29,7 +29,7 @@ if [ $f_res -eq 1 ]; then
     -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
     -DLLVM_ENABLE_ASSERTIONS=Off
 
-  $MAKE -f tools/dsymutil/Makefile -j$JOBS
+  $CMAKE --build . --target llvm-dsymutil -j$JOBS
   cp bin/llvm-dsymutil $OSXCROSS_TARGET_DIR/bin/osxcross-llvm-dsymutil
   echo "installed llvm-dsymutil to $OSXCROSS_TARGET_DIR/bin/osxcross-llvm-dsymutil"
 


### PR DESCRIPTION
Not sure if this is the best (quickest) way to do this.

I found this `./build_llvm_dsymutil.sh` script failed for me because it assumed I was using `GNU Make` as my default CMake generator when in this case I'm using `Ninja`.

However, I do not know if this is slower than using the `tools/dsymutil/Makefile` directly because maybe the CMake target builds extraneous stuff?

🤷‍♂️

Also is it necessary to build a custom fork of this utility from the LLVM fork?

It appears in LLVM's `master` the [relevant changes](https://github.com/llvm-mirror/llvm/compare/master...tpoechtrager:llvm-dsymutil:master) are now in the upstream?

- [Addition of `&& AttrInfo.Name`](https://github.com/llvm-mirror/llvm/blob/master/tools/dsymutil/DwarfLinker.cpp#L1641)
- [Ability to set `lipo` program location via environment variable](https://github.com/llvm-mirror/llvm/compare/master...tpoechtrager:llvm-dsymutil:master#diff-0375c79709bace24cc3b0976fe21f457df69fa92de77275ac6eff19c480fb858R37-R42), why not just put `lipo` where LLVM expects?