### PR TITLE
Fix detection for intrinsic clang headers on Fedora

### DIFF
--- a/wrapper/target.cpp
+++ b/wrapper/target.cpp
@@ -426,7 +426,7 @@ do {                                                                           \
   // opensuse uses lib64 instead of lib on x86_64
   TRYDIR2("/../lib64/clang");
   // Fedora installs clang into /usr/lib64/llvm*
-  TRYDIR3("/../../../lib/clang/");
+  TRYDIR2("/../../../lib/clang/");
 #elif __i386__
   TRYDIR2("/../lib32/clang");
 #endif

--- a/wrapper/target.cpp
+++ b/wrapper/target.cpp
@@ -425,6 +425,8 @@ do {                                                                           \
 #ifdef __x86_64__
   // opensuse uses lib64 instead of lib on x86_64
   TRYDIR2("/../lib64/clang");
+  // Fedora installs clang into /usr/lib64/llvm*
+  TRYDIR3("/../../../lib/clang/");
 #elif __i386__
   TRYDIR2("/../lib32/clang");
 #endif


### PR DESCRIPTION
Due to the install location of clang on Fedora (in /usr/lib64/llvm20 for clang 20 for example) The header search will eventually hit the fallback search for `../include/clang` and find a match, however the directory it finds doesn't include clang headers.

Instead Fedora installs it's clang headers under `/usr/lib/clang/20/include`. This fix ensures that directory is resolved before any of the fallbacks are hit.