### PR TITLE
Allow __apple_build_version__ exposure from apple-clang wrapper

### DIFF
--- a/wrapper/target.cpp
+++ b/wrapper/target.cpp
@@ -911,6 +911,11 @@ bool Target::setup() {
 #endif
 
   if (isClang()) {
+    if (getenv("OSXCROSS_PRETEND_TO_BE_APPLE_CLANG"))
+    {
+        fargs.push_back("-D__apple_build_version__=1");
+    }
+
     if (SDKOSNum >= OSVersion(14, 0) && clangversion < ClangVersion(17, 0)) {
       // MacOS 14 SDK uses __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__ in AvailabilityInternal.h
       fargs.push_back("-D__ENVIRONMENT_OS_VERSION_MIN_REQUIRED__=" + OSNum.numStr());


### PR DESCRIPTION
# Context
See issue: https://github.com/tpoechtrager/osxcross/issues/463

# Test

Simple .cpp file:
~~~
$ cat testCompiler.cpp 
#include <iostream>

int main(void)
{
#ifdef __apple_build_version__
    std::cout << "__apple_build_version__ set" << std::endl;
#else
    std::cout << "__apple_build_version__ NOT set" << std::endl;
#endif

#ifdef __clang__
    std::cout << "__clang__ set" << std::endl;
#else
    std::cout << "__clang__ NOT set" << std::endl;
#endif
}
~~~

Run command:
~~~
/usr/local/osxcross/bin/aarch64-apple-darwin20.2-clang++ -E testCompiler.cpp
~~~
Check result:
~~~
std::cout << "__apple_build_version__ NOT set" << std::endl;
~~~
Then run:
~~~
export OSXCROSS_PRETEND_TO_BE_APPLE_CLANG=1
/usr/local/osxcross/bin/aarch64-apple-darwin20.2-clang++ -E testCompiler.cpp
~~~
Check result:
~~~
std::cout << "__apple_build_version__ set" << std::endl;
~~~