### PR TITLE
Adds OSXCROSS_LET_TOOLCHAIN_SET_MIN_VERSION env variable

### DIFF
--- a/wrapper/target.cpp
+++ b/wrapper/target.cpp
@@ -843,7 +843,7 @@ bool Target::setup() {
     fargs.push_back(ClangIntrinsicPath);
   }
 
-  if (OSNum.Num()) {
+  if (!getenv("OSXCROSS_LET_TOOLCHAIN_SET_MIN_VERSION") && OSNum.Num()) {
     std::string tmp;
     tmp = "-mmacosx-version-min=";
     if (isClang() && clangversion < ClangVersion(11, 0) &&


### PR DESCRIPTION
# Use case

3rd parties management tools like conan, use conan profiles to define the binaries they create.
These profiles are declarative.

Osxcross clang wrapper is setting -mmacosx-version-min, which overrides conan profiles.

# Solution

I am suggesting this solution to let users disengage this variable and let, for instance conan, manage the binaries parameters.