### PR TITLE
Fix ENABLE_ARCHS processing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -79,7 +79,7 @@ if [ -n "$ENABLE_ARCHS" ]; then
     fi
   done
   # trim + normalize whitespace
-  SUPPORTED_ARCHS="$(printf '%s\n' $ENABLE_ARCHS)"
+  SUPPORTED_ARCHS="$(echo $ENABLE_ARCHS | xargs)"
 fi
 
 # Minimum targeted macOS version


### PR DESCRIPTION
`ENABLE_ARCHS` variable doesn't seem to work properly. When defined, each arch in `SUPPORTED_ARCHS` ends up being separated by a new line character rather than a whitespace, which makes `first_supported_arch` function not work as expected.