### PR TITLE
Add Objective-C compiler settings to toolchain

### DIFF
--- a/tools/toolchain.cmake
+++ b/tools/toolchain.cmake
@@ -23,6 +23,8 @@ string(REGEX REPLACE "-.*" "" CMAKE_SYSTEM_PROCESSOR "${OSXCROSS_HOST}")
 # specify the cross compiler
 set(CMAKE_C_COMPILER "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-clang")
 set(CMAKE_CXX_COMPILER "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-clang++")
+set(CMAKE_OBJC_COMPILER "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-clang")
+set(CMAKE_OBJCXX_COMPILER "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-clang++")
 
 # where is the target environment
 set(CMAKE_FIND_ROOT_PATH


### PR DESCRIPTION
CMake Projects that depend on an OBJC Compiler do not work (e.g. MoltenVK). This fixed that.