### PR TITLE
add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 cpucount
 build/
 target/
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769461804,
-        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,16 +21,28 @@
         # Import the helper library
         osxcrossLib = import ./nix/lib.nix {inherit (pkgs) lib;};
 
+        # Get SDK path from env var as fallback
+        envSdkPath = builtins.getEnv "MACOS_SDK";
+
         # Function to build osxcross with configuration
         mkOsxcross = {
-          sdkPath,
+          sdkPath ? null,
           sdkVersion ? null,
           osxVersionMin ? null,
           enableArchs ? null,
           enableLTO ? true,
-        }:
+        }: let
+          # Manual config (sdkPath argument) takes precedence over env var
+          effectiveSdkPath =
+            if sdkPath != null
+            then sdkPath
+            else if envSdkPath != ""
+            then envSdkPath
+            else throw "SDK path required: either pass sdkPath argument or set MACOS_SDK environment variable (requires --impure flag)";
+        in
           pkgs.callPackage ./nix/osxcross.nix {
-            inherit osxcrossLib sdkPath sdkVersion osxVersionMin enableArchs enableLTO;
+            inherit osxcrossLib sdkVersion osxVersionMin enableArchs enableLTO;
+            sdkPath = effectiveSdkPath;
             src = self;
           };
 
@@ -50,7 +62,7 @@
             ==================
 
             OSXCross requires a macOS SDK tarball due to Apple licensing.
-            You must provide the SDK path when building.
+            You can provide the SDK path via argument or environment variable.
 
             Usage in a flake:
             -----------------
@@ -66,9 +78,15 @@
               };
             }
 
+            Using MACOS_SDK environment variable:
+            -------------------------------------
+            export MACOS_SDK=/path/to/MacOSX14.5.sdk.tar.xz
+            nix build --impure  # --impure required for env var access
+
             Available options for mkOsxcross:
             ---------------------------------
-            - sdkPath      (required) Path to macOS SDK tarball
+            - sdkPath      (optional) Path to macOS SDK tarball
+                           Falls back to MACOS_SDK env var if not provided
             - sdkVersion   (optional) SDK version, auto-detected from filename
             - osxVersionMin(optional) Minimum deployment target
             - enableArchs  (optional) List of architectures: ["arm64" "x86_64"]
@@ -109,18 +127,28 @@
     )
     // {
       # Overlay for use with nixpkgs overlays
-      overlays.default = final: prev: {
+      overlays.default = final: prev: let
+        envSdkPath = builtins.getEnv "MACOS_SDK";
+      in {
         osxcross = {
           mkOsxcross = {
-            sdkPath,
+            sdkPath ? null,
             sdkVersion ? null,
             osxVersionMin ? null,
             enableArchs ? null,
             enableLTO ? true,
-          }:
+          }: let
+            effectiveSdkPath =
+              if sdkPath != null
+              then sdkPath
+              else if envSdkPath != ""
+              then envSdkPath
+              else throw "SDK path required: either pass sdkPath argument or set MACOS_SDK environment variable (requires --impure flag)";
+          in
             final.callPackage ./nix/osxcross.nix {
               osxcrossLib = import ./nix/lib.nix {inherit (final) lib;};
-              inherit sdkPath sdkVersion osxVersionMin enableArchs enableLTO;
+              inherit sdkVersion osxVersionMin enableArchs enableLTO;
+              sdkPath = effectiveSdkPath;
               src = self;
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,15 @@
             inherit (pkgs) lib;
             inherit pkgs osxcross;
           };
+
+        # Shell hook snippet for SDK detection (reusable by consumers)
+        sdkShellHook = ''
+          if [ -n "''${MACOS_SDK:-}" ]; then
+            echo "SDK: $MACOS_SDK (from MACOS_SDK env var)"
+          else
+            echo "SDK: not found (set MACOS_SDK env var or pass sdkPath to mkOsxcross)"
+          fi
+        '';
       in {
         # Package outputs
         packages = {
@@ -108,11 +117,11 @@
         };
 
         # Development shell for working on osxcross itself
-        devShells.default = import ./nix/devshell.nix {inherit pkgs;};
+        devShells.default = import ./nix/devshell.nix {inherit pkgs sdkShellHook;};
 
         # Library outputs for use in other flakes
         lib = {
-          inherit mkOsxcross mkRustHelpers osxcrossLib;
+          inherit mkOsxcross mkRustHelpers osxcrossLib sdkShellHook;
 
           # Convenience: get Rust targets for an SDK version
           getRustTargets = osxcrossLib.getRustTargets;

--- a/flake.nix
+++ b/flake.nix
@@ -90,50 +90,7 @@
         };
 
         # Development shell for working on osxcross itself
-        devShells.default = pkgs.mkShell {
-          name = "osxcross-dev";
-
-          buildInputs = with pkgs; [
-            # Build tools
-            clang
-            llvmPackages.llvm
-            cmake
-            gnumake
-            autoconf
-            automake
-            libtool
-            pkg-config
-
-            # Required dependencies
-            git
-            gnupatch
-            python3
-            openssl
-            xz
-            libxml2
-            bzip2
-            cpio
-            zlib
-            bash
-            libuuid
-
-            # Optional but recommended
-            curl
-            wget
-          ];
-
-          shellHook = ''
-            echo "OSXCross development environment"
-            echo ""
-            echo "To build osxcross manually:"
-            echo "  1. Place SDK tarball in ./tarballs/"
-            echo "  2. Run: ./build.sh"
-            echo ""
-            echo "To use Nix flake:"
-            echo "  nix build .#mkOsxcross --impure"
-            echo ""
-          '';
-        };
+        devShells.default = import ./nix/devshell.nix {inherit pkgs;};
 
         # Library outputs for use in other flakes
         lib = {

--- a/flake.nix
+++ b/flake.nix
@@ -24,26 +24,86 @@
         # Get SDK path from env var as fallback
         envSdkPath = builtins.getEnv "MACOS_SDK";
 
+        isMacosSdkRef = value:
+          builtins.isAttrs value
+          && value ? _type
+          && value._type == "osxcross-macos-sdk"
+          && value ? sdk
+          && value ? sdkRoot
+          && value ? sdkVersion;
+
+        mkMacosSdkRef = {
+          sdk,
+          sdkVersion,
+          sdkRoot ? "${sdk}/MacOSX${sdkVersion}.sdk",
+        }:
+          assert sdkVersion != null && builtins.isString sdkVersion
+            || throw "osxcross: mkMacosSdkRef 'sdkVersion' must be a string";
+          assert builtins.stringLength sdkVersion > 0
+            || throw "osxcross: mkMacosSdkRef 'sdkVersion' must not be empty";
+          {
+            _type = "osxcross-macos-sdk";
+            inherit sdk sdkVersion;
+            sdkRoot = toString sdkRoot;
+          };
+
+        mkMacosSdk = {
+          sdkArchive,
+          sdkVersion ? null,
+          outputHash ? null,
+        }: let
+          detectedSdkVersion =
+            if sdkVersion != null
+            then sdkVersion
+            else osxcrossLib.detectSdkVersion (builtins.baseNameOf (toString sdkArchive));
+          sdk = pkgs.callPackage ./nix/sdk.nix {
+            sdkTarball = sdkArchive;
+            sdkVersion = detectedSdkVersion;
+            inherit outputHash;
+          };
+        in
+          mkMacosSdkRef {
+            inherit sdk;
+            sdkVersion = detectedSdkVersion;
+          };
+
+        normalizeMacosSdk = macosSdk:
+          if isMacosSdkRef macosSdk
+          then macosSdk
+          else throw "osxcross: expected a macOS SDK ref from mkMacosSdk or mkMacosSdkRef";
+
         # Function to build osxcross with configuration
         mkOsxcross = {
+          macosSdk ? null,
           sdkPath ? null,
           sdkVersion ? null,
           osxVersionMin ? null,
           enableArchs ? null,
           enableLTO ? true,
         }: let
-          # Manual config (sdkPath argument) takes precedence over env var
-          # Convert env var string to a Nix path so the file gets copied into the store
+          # macosSdk is preferred. Legacy sdkPath takes precedence over env var.
+          # Convert env var string to a Nix path so the file gets copied into the store.
           effectiveSdkPath =
             if sdkPath != null
             then sdkPath
             else if envSdkPath != ""
             then /. + envSdkPath
-            else throw "SDK path required: either pass sdkPath argument or set MACOS_SDK environment variable (requires --impure flag)";
+            else null;
+
+          effectiveMacosSdk =
+            if macosSdk != null
+            then normalizeMacosSdk macosSdk
+            else if effectiveSdkPath != null
+            then
+              mkMacosSdk {
+                sdkArchive = effectiveSdkPath;
+                inherit sdkVersion;
+              }
+            else throw "SDK required: pass macosSdk, pass sdkPath, or set MACOS_SDK (legacy impure fallback)";
         in
           pkgs.callPackage ./nix/osxcross.nix {
             inherit osxcrossLib sdkVersion osxVersionMin enableArchs enableLTO;
-            sdkPath = effectiveSdkPath;
+            macosSdk = effectiveMacosSdk;
             src = self;
           };
 
@@ -59,9 +119,30 @@
           if [ -n "''${MACOS_SDK:-}" ]; then
             echo "SDK: $MACOS_SDK (from MACOS_SDK env var)"
           else
-            echo "SDK: not found (set MACOS_SDK env var or pass sdkPath to mkOsxcross)"
+            echo "SDK: not found (pass macosSdk, pass sdkPath, or set MACOS_SDK for legacy impure fallback)"
           fi
         '';
+
+        fakeSdkArchive = pkgs.runCommand "MacOSX26.1.sdk.tar" {
+          nativeBuildInputs = [pkgs.gnutar];
+        } ''
+          mkdir -p MacOSX26.1.sdk/usr/include/c++/v1
+          cat > MacOSX26.1.sdk/SDKSettings.json <<'JSON'
+          {"Version":"26.1"}
+          JSON
+          tar cf "$out" MacOSX26.1.sdk
+        '';
+
+        fakeMacosSdk = mkMacosSdk {
+          sdkArchive = fakeSdkArchive;
+          sdkVersion = "26.1";
+        };
+
+        fakeToolchain = mkOsxcross {
+          macosSdk = fakeMacosSdk;
+          enableArchs = ["x86_64"];
+          enableLTO = false;
+        };
       in {
         # Package outputs
         packages = {
@@ -72,17 +153,26 @@
             ==================
 
             OSXCross requires a macOS SDK tarball due to Apple licensing.
-            You can provide the SDK path via argument or environment variable.
+            Prefer a shared macOS SDK ref. Legacy sdkPath and MACOS_SDK are still supported.
 
             Usage in a flake:
             -----------------
             {
               inputs.osxcross.url = "github:tpoechtrager/osxcross";
+              inputs.macos-sdk-archive = {
+                url = "file:///path/to/MacOSX14.5.sdk.tar.xz";
+                flake = false;
+              };
 
-              outputs = { osxcross, ... }: {
+              outputs = { osxcross, macos-sdk-archive, ... }: {
                 packages.x86_64-linux.myApp = let
+                  macosSdk = osxcross.lib.x86_64-linux.mkMacosSdk {
+                    sdkArchive = macos-sdk-archive;
+                    sdkVersion = "14.5";
+                    # outputHash = "sha256-...";
+                  };
                   toolchain = osxcross.lib.x86_64-linux.mkOsxcross {
-                    sdkPath = ./MacOSX14.5.sdk.tar.xz;
+                    inherit macosSdk;
                   };
                 in ...;
               };
@@ -95,6 +185,7 @@
 
             Available options for mkOsxcross:
             ---------------------------------
+            - macosSdk     (preferred) SDK ref from mkMacosSdk or mkMacosSdkRef
             - sdkPath      (optional) Path to macOS SDK tarball
                            Falls back to MACOS_SDK env var if not provided
             - sdkVersion   (optional) SDK version, auto-detected from filename
@@ -120,9 +211,42 @@
         # Development shell for working on osxcross itself
         devShells.default = import ./nix/devshell.nix {inherit pkgs sdkShellHook;};
 
+        checks =
+          {
+            macos-sdk-no-aliases = pkgs.runCommand "check-macos-sdk-no-aliases" {} ''
+              test -d "${fakeMacosSdk.sdkRoot}"
+              for path in \
+                "${fakeMacosSdk.sdk}/MacOSX.sdk" \
+                "${fakeMacosSdk.sdk}/MacOSX26.sdk" \
+                "${fakeMacosSdk.sdk}/default"
+              do
+                test ! -e "$path"
+                test ! -L "$path"
+              done
+              touch "$out"
+            '';
+          }
+          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            osxcross-direct-sdk-root = pkgs.runCommand "check-osxcross-direct-sdk-root" {} ''
+              test ! -e "${fakeToolchain}/SDK"
+              test ! -L "${fakeToolchain}/SDK"
+              test "$("${fakeToolchain}/bin/xcrun" -show-sdk-path)" = "${fakeMacosSdk.sdkRoot}"
+              "${fakeToolchain}/bin/osxcross-conf" | grep 'export OSXCROSS_SDK="${fakeMacosSdk.sdkRoot}"'
+              touch "$out"
+            '';
+          };
+
         # Library outputs for use in other flakes
         lib = {
-          inherit mkOsxcross mkRustHelpers osxcrossLib sdkShellHook;
+          inherit
+            mkMacosSdk
+            mkMacosSdkRef
+            isMacosSdkRef
+            mkOsxcross
+            mkRustHelpers
+            osxcrossLib
+            sdkShellHook
+            ;
 
           # Convenience: get Rust targets for an SDK version
           getRustTargets = osxcrossLib.getRustTargets;
@@ -139,9 +263,61 @@
       # Overlay for use with nixpkgs overlays
       overlays.default = final: prev: let
         envSdkPath = builtins.getEnv "MACOS_SDK";
+        osxcrossLib = import ./nix/lib.nix {inherit (final) lib;};
+
+        isMacosSdkRef = value:
+          builtins.isAttrs value
+          && value ? _type
+          && value._type == "osxcross-macos-sdk"
+          && value ? sdk
+          && value ? sdkRoot
+          && value ? sdkVersion;
+
+        mkMacosSdkRef = {
+          sdk,
+          sdkVersion,
+          sdkRoot ? "${sdk}/MacOSX${sdkVersion}.sdk",
+        }:
+          assert sdkVersion != null && builtins.isString sdkVersion
+            || throw "osxcross: mkMacosSdkRef 'sdkVersion' must be a string";
+          assert builtins.stringLength sdkVersion > 0
+            || throw "osxcross: mkMacosSdkRef 'sdkVersion' must not be empty";
+          {
+            _type = "osxcross-macos-sdk";
+            inherit sdk sdkVersion;
+            sdkRoot = toString sdkRoot;
+          };
+
+        mkMacosSdk = {
+          sdkArchive,
+          sdkVersion ? null,
+          outputHash ? null,
+        }: let
+          detectedSdkVersion =
+            if sdkVersion != null
+            then sdkVersion
+            else osxcrossLib.detectSdkVersion (builtins.baseNameOf (toString sdkArchive));
+          sdk = final.callPackage ./nix/sdk.nix {
+            sdkTarball = sdkArchive;
+            sdkVersion = detectedSdkVersion;
+            inherit outputHash;
+          };
+        in
+          mkMacosSdkRef {
+            inherit sdk;
+            sdkVersion = detectedSdkVersion;
+          };
+
+        normalizeMacosSdk = macosSdk:
+          if isMacosSdkRef macosSdk
+          then macosSdk
+          else throw "osxcross: expected a macOS SDK ref from mkMacosSdk or mkMacosSdkRef";
       in {
         osxcross = {
+          inherit mkMacosSdk mkMacosSdkRef isMacosSdkRef;
+
           mkOsxcross = {
+            macosSdk ? null,
             sdkPath ? null,
             sdkVersion ? null,
             osxVersionMin ? null,
@@ -153,12 +329,23 @@
               then sdkPath
               else if envSdkPath != ""
               then /. + envSdkPath
-              else throw "SDK path required: either pass sdkPath argument or set MACOS_SDK environment variable (requires --impure flag)";
+              else null;
+
+            effectiveMacosSdk =
+              if macosSdk != null
+              then normalizeMacosSdk macosSdk
+              else if effectiveSdkPath != null
+              then
+                mkMacosSdk {
+                  sdkArchive = effectiveSdkPath;
+                  inherit sdkVersion;
+                }
+              else throw "SDK required: pass macosSdk, pass sdkPath, or set MACOS_SDK (legacy impure fallback)";
           in
             final.callPackage ./nix/osxcross.nix {
-              osxcrossLib = import ./nix/lib.nix {inherit (final) lib;};
+              inherit osxcrossLib;
               inherit sdkVersion osxVersionMin enableArchs enableLTO;
-              sdkPath = effectiveSdkPath;
+              macosSdk = effectiveMacosSdk;
               src = self;
             };
 
@@ -169,7 +356,7 @@
               inherit osxcross;
             };
 
-          lib = import ./nix/lib.nix {inherit (final) lib;};
+          lib = osxcrossLib;
         };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,6 @@
         # Import the helper library
         osxcrossLib = import ./nix/lib.nix {inherit (pkgs) lib;};
 
-        # Get SDK path from env var as fallback
-        envSdkPath = builtins.getEnv "MACOS_SDK";
-
         isMacosSdkRef = value:
           builtins.isAttrs value
           && value ? _type
@@ -75,31 +72,15 @@
         # Function to build osxcross with configuration
         mkOsxcross = {
           macosSdk ? null,
-          sdkPath ? null,
           sdkVersion ? null,
           osxVersionMin ? null,
           enableArchs ? null,
           enableLTO ? true,
         }: let
-          # macosSdk is preferred. Legacy sdkPath takes precedence over env var.
-          # Convert env var string to a Nix path so the file gets copied into the store.
-          effectiveSdkPath =
-            if sdkPath != null
-            then sdkPath
-            else if envSdkPath != ""
-            then /. + envSdkPath
-            else null;
-
           effectiveMacosSdk =
             if macosSdk != null
             then normalizeMacosSdk macosSdk
-            else if effectiveSdkPath != null
-            then
-              mkMacosSdk {
-                sdkArchive = effectiveSdkPath;
-                inherit sdkVersion;
-              }
-            else throw "SDK required: pass macosSdk, pass sdkPath, or set MACOS_SDK (legacy impure fallback)";
+            else throw "osxcross: mkOsxcross requires macosSdk; SDK discovery belongs in a higher-level policy layer";
         in
           pkgs.callPackage ./nix/osxcross.nix {
             inherit osxcrossLib sdkVersion osxVersionMin enableArchs enableLTO;
@@ -116,10 +97,10 @@
 
         # Shell hook snippet for SDK detection (reusable by consumers)
         sdkShellHook = ''
-          if [ -n "''${MACOS_SDK:-}" ]; then
-            echo "SDK: $MACOS_SDK (from MACOS_SDK env var)"
+          if [ -n "''${OSXCROSS_SDKROOT:-}" ]; then
+            echo "SDK: $OSXCROSS_SDKROOT (from OSXCROSS_SDKROOT)"
           else
-            echo "SDK: not found (pass macosSdk, pass sdkPath, or set MACOS_SDK for legacy impure fallback)"
+            echo "SDK: not configured (pass macosSdk to mkOsxcross)"
           fi
         '';
 
@@ -128,7 +109,14 @@
           osxcross = self;
         };
 
-        fakeSdkArchive = pkgs.runCommand "MacOSX26.1.sdk.tar" {
+        fakeSdkRoot = pkgs.runCommand "fake-MacOSX26.1.sdk" {} ''
+          mkdir -p "$out/usr/include/c++/v1"
+          cat > "$out/SDKSettings.json" <<'JSON'
+          {"Version":"26.1"}
+          JSON
+        '';
+
+        fakeSdkArchive = pkgs.runCommand "fake-MacOSX26.1.sdk.tar" {
           nativeBuildInputs = [pkgs.gnutar];
         } ''
           mkdir -p MacOSX26.1.sdk/usr/include/c++/v1
@@ -138,8 +126,9 @@
           tar cf "$out" MacOSX26.1.sdk
         '';
 
-        fakeMacosSdk = mkMacosSdk {
-          sdkArchive = fakeSdkArchive;
+        fakeMacosSdk = mkMacosSdkRef {
+          sdk = fakeSdkRoot;
+          sdkRoot = fakeSdkRoot;
           sdkVersion = "26.1";
         };
 
@@ -157,8 +146,8 @@
             OSXCross Nix Flake
             ==================
 
-            OSXCross requires a macOS SDK tarball due to Apple licensing.
-            Prefer a shared macOS SDK ref. Legacy sdkPath and MACOS_SDK are still supported.
+            OSXCross requires a macOS SDK due to Apple licensing.
+            Pass an explicit macOS SDK ref to mkOsxcross.
 
             One-time SDK realization:
             -------------------------
@@ -187,17 +176,10 @@
               };
             }
 
-            Using MACOS_SDK environment variable:
-            -------------------------------------
-            export MACOS_SDK=/path/to/MacOSX14.5.sdk.tar.xz
-            nix build --impure  # --impure required for env var access
-
             Available options for mkOsxcross:
             ---------------------------------
-            - macosSdk     (preferred) SDK ref from mkMacosSdk or mkMacosSdkRef
-            - sdkPath      (optional) Path to macOS SDK tarball
-                           Falls back to MACOS_SDK env var if not provided
-            - sdkVersion   (optional) SDK version, auto-detected from filename
+            - macosSdk     (required) SDK ref from mkMacosSdk or mkMacosSdkRef
+            - sdkVersion   (optional) SDK version override
             - osxVersionMin(optional) Minimum deployment target
             - enableArchs  (optional) List of architectures: ["arm64" "x86_64"]
             - enableLTO    (optional) Enable LTO support (default: true)
@@ -232,16 +214,28 @@
           {
             macos-sdk-no-aliases = pkgs.runCommand "check-macos-sdk-no-aliases" {} ''
               test -d "${fakeMacosSdk.sdkRoot}"
-              for path in \
-                "${fakeMacosSdk.sdk}/MacOSX.sdk" \
-                "${fakeMacosSdk.sdk}/MacOSX26.sdk" \
-                "${fakeMacosSdk.sdk}/default"
-              do
-                test ! -e "$path"
-                test ! -L "$path"
-              done
+              test ! -e "${fakeMacosSdk.sdk}/MacOSX.sdk"
+              test ! -L "${fakeMacosSdk.sdk}/MacOSX.sdk"
+              test ! -e "${fakeMacosSdk.sdk}/MacOSX26.sdk"
+              test ! -L "${fakeMacosSdk.sdk}/MacOSX26.sdk"
+              test ! -e "${fakeMacosSdk.sdk}/default"
+              test ! -L "${fakeMacosSdk.sdk}/default"
               touch "$out"
             '';
+
+            macos-sdk-ref-direct-root =
+              assert fakeMacosSdk.sdkRoot == toString fakeSdkRoot;
+                pkgs.runCommand "check-macos-sdk-ref-direct-root" {} "touch $out";
+
+            mkosxcross-requires-macos-sdk = let
+              missingSdk = builtins.tryEval ((mkOsxcross {
+                  enableArchs = ["x86_64"];
+                  enableLTO = false;
+                })
+                .drvPath);
+            in
+              assert missingSdk.success == false;
+                pkgs.runCommand "check-mkosxcross-requires-macos-sdk" {} "touch $out";
 
             realize-macos-sdk-help = pkgs.runCommand "check-realize-macos-sdk-help" {} ''
               "${realizeMacosSdk}/bin/realize-macos-sdk" --help > help
@@ -287,7 +281,6 @@
     // {
       # Overlay for use with nixpkgs overlays
       overlays.default = final: prev: let
-        envSdkPath = builtins.getEnv "MACOS_SDK";
         osxcrossLib = import ./nix/lib.nix {inherit (final) lib;};
 
         isMacosSdkRef = value:
@@ -343,29 +336,15 @@
 
           mkOsxcross = {
             macosSdk ? null,
-            sdkPath ? null,
             sdkVersion ? null,
             osxVersionMin ? null,
             enableArchs ? null,
             enableLTO ? true,
           }: let
-            effectiveSdkPath =
-              if sdkPath != null
-              then sdkPath
-              else if envSdkPath != ""
-              then /. + envSdkPath
-              else null;
-
             effectiveMacosSdk =
               if macosSdk != null
               then normalizeMacosSdk macosSdk
-              else if effectiveSdkPath != null
-              then
-                mkMacosSdk {
-                  sdkArchive = effectiveSdkPath;
-                  inherit sdkVersion;
-                }
-              else throw "SDK required: pass macosSdk, pass sdkPath, or set MACOS_SDK (legacy impure fallback)";
+              else throw "osxcross: mkOsxcross requires macosSdk; SDK discovery belongs in a higher-level policy layer";
           in
             final.callPackage ./nix/osxcross.nix {
               inherit osxcrossLib;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,181 @@
+{
+  description = "OSXCross - macOS cross-compilation toolchain for Linux";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+
+        # Import the helper library
+        osxcrossLib = import ./nix/lib.nix {inherit (pkgs) lib;};
+
+        # Function to build osxcross with configuration
+        mkOsxcross = {
+          sdkPath,
+          sdkVersion ? null,
+          osxVersionMin ? null,
+          enableArchs ? null,
+          enableLTO ? true,
+        }:
+          pkgs.callPackage ./nix/osxcross.nix {
+            inherit osxcrossLib sdkPath sdkVersion osxVersionMin enableArchs enableLTO;
+            src = self;
+          };
+
+        # Rust helpers factory (requires a built osxcross)
+        mkRustHelpers = osxcross:
+          import ./nix/rust.nix {
+            inherit (pkgs) lib;
+            inherit pkgs osxcross;
+          };
+      in {
+        # Package outputs
+        packages = {
+          # Default package - provides usage instructions
+          default = pkgs.writeShellScriptBin "osxcross-help" ''
+            cat << 'EOF'
+            OSXCross Nix Flake
+            ==================
+
+            OSXCross requires a macOS SDK tarball due to Apple licensing.
+            You must provide the SDK path when building.
+
+            Usage in a flake:
+            -----------------
+            {
+              inputs.osxcross.url = "github:tpoechtrager/osxcross";
+
+              outputs = { osxcross, ... }: {
+                packages.x86_64-linux.myApp = let
+                  toolchain = osxcross.lib.x86_64-linux.mkOsxcross {
+                    sdkPath = ./MacOSX14.5.sdk.tar.xz;
+                  };
+                in ...;
+              };
+            }
+
+            Available options for mkOsxcross:
+            ---------------------------------
+            - sdkPath      (required) Path to macOS SDK tarball
+            - sdkVersion   (optional) SDK version, auto-detected from filename
+            - osxVersionMin(optional) Minimum deployment target
+            - enableArchs  (optional) List of architectures: ["arm64" "x86_64"]
+            - enableLTO    (optional) Enable LTO support (default: true)
+
+            For Rust cross-compilation:
+            ---------------------------
+            rustHelpers = osxcross.lib.x86_64-linux.mkRustHelpers toolchain;
+
+            See README for more details.
+            EOF
+          '';
+
+          # Standalone XAR tool
+          xar = pkgs.callPackage ./nix/xar.nix {};
+
+          # Standalone Apple TAPI library
+          apple-libtapi = pkgs.callPackage ./nix/apple-libtapi.nix {};
+        };
+
+        # Development shell for working on osxcross itself
+        devShells.default = pkgs.mkShell {
+          name = "osxcross-dev";
+
+          buildInputs = with pkgs; [
+            # Build tools
+            clang
+            llvmPackages.llvm
+            cmake
+            gnumake
+            autoconf
+            automake
+            libtool
+            pkg-config
+
+            # Required dependencies
+            git
+            gnupatch
+            python3
+            openssl
+            xz
+            libxml2
+            bzip2
+            cpio
+            zlib
+            bash
+            libuuid
+
+            # Optional but recommended
+            curl
+            wget
+          ];
+
+          shellHook = ''
+            echo "OSXCross development environment"
+            echo ""
+            echo "To build osxcross manually:"
+            echo "  1. Place SDK tarball in ./tarballs/"
+            echo "  2. Run: ./build.sh"
+            echo ""
+            echo "To use Nix flake:"
+            echo "  nix build .#mkOsxcross --impure"
+            echo ""
+          '';
+        };
+
+        # Library outputs for use in other flakes
+        lib = {
+          inherit mkOsxcross mkRustHelpers osxcrossLib;
+
+          # Convenience: get Rust targets for an SDK version
+          getRustTargets = osxcrossLib.getRustTargets;
+
+          # Convenience: get target info for an SDK version
+          getTargetInfo = osxcrossLib.getTargetInfo;
+
+          # Convenience: detect SDK version from filename
+          detectSdkVersion = osxcrossLib.detectSdkVersion;
+        };
+      }
+    )
+    // {
+      # Overlay for use with nixpkgs overlays
+      overlays.default = final: prev: {
+        osxcross = {
+          mkOsxcross = {
+            sdkPath,
+            sdkVersion ? null,
+            osxVersionMin ? null,
+            enableArchs ? null,
+            enableLTO ? true,
+          }:
+            final.callPackage ./nix/osxcross.nix {
+              osxcrossLib = import ./nix/lib.nix {inherit (final) lib;};
+              inherit sdkPath sdkVersion osxVersionMin enableArchs enableLTO;
+              src = self;
+            };
+
+          mkRustHelpers = osxcross:
+            import ./nix/rust.nix {
+              inherit (final) lib;
+              pkgs = final;
+              inherit osxcross;
+            };
+
+          lib = import ./nix/lib.nix {inherit (final) lib;};
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,11 @@
           fi
         '';
 
+        realizeMacosSdk = import ./nix/realize-macos-sdk.nix {
+          inherit pkgs;
+          osxcross = self;
+        };
+
         fakeSdkArchive = pkgs.runCommand "MacOSX26.1.sdk.tar" {
           nativeBuildInputs = [pkgs.gnutar];
         } ''
@@ -154,6 +159,10 @@
 
             OSXCross requires a macOS SDK tarball due to Apple licensing.
             Prefer a shared macOS SDK ref. Legacy sdkPath and MACOS_SDK are still supported.
+
+            One-time SDK realization:
+            -------------------------
+            nix run .#realize-macos-sdk -- /path/to/MacOSX14.5.sdk.tar.xz 14.5
 
             Usage in a flake:
             -----------------
@@ -206,6 +215,14 @@
 
           # Standalone Apple TAPI library
           apple-libtapi = pkgs.callPackage ./nix/apple-libtapi.nix {};
+
+          # Realize a stable macOS SDK store path from a local archive
+          realize-macos-sdk = realizeMacosSdk;
+        };
+
+        apps.realize-macos-sdk = {
+          type = "app";
+          program = "${realizeMacosSdk}/bin/realize-macos-sdk";
         };
 
         # Development shell for working on osxcross itself
@@ -223,6 +240,14 @@
                 test ! -e "$path"
                 test ! -L "$path"
               done
+              touch "$out"
+            '';
+
+            realize-macos-sdk-help = pkgs.runCommand "check-realize-macos-sdk-help" {} ''
+              "${realizeMacosSdk}/bin/realize-macos-sdk" --help > help
+              grep 'realize-macos-sdk \[--env\]' help
+              grep 'Recursive hash' help
+              grep -- '--env' help
               touch "$out"
             '';
           }

--- a/flake.nix
+++ b/flake.nix
@@ -33,11 +33,12 @@
           enableLTO ? true,
         }: let
           # Manual config (sdkPath argument) takes precedence over env var
+          # Convert env var string to a Nix path so the file gets copied into the store
           effectiveSdkPath =
             if sdkPath != null
             then sdkPath
             else if envSdkPath != ""
-            then envSdkPath
+            then /. + envSdkPath
             else throw "SDK path required: either pass sdkPath argument or set MACOS_SDK environment variable (requires --impure flag)";
         in
           pkgs.callPackage ./nix/osxcross.nix {
@@ -151,7 +152,7 @@
               if sdkPath != null
               then sdkPath
               else if envSdkPath != ""
-              then envSdkPath
+              then /. + envSdkPath
               else throw "SDK path required: either pass sdkPath argument or set MACOS_SDK environment variable (requires --impure flag)";
           in
             final.callPackage ./nix/osxcross.nix {

--- a/nix/README.md
+++ b/nix/README.md
@@ -12,17 +12,27 @@ A Nix flake for building macOS cross-compilation toolchains on Linux.
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     osxcross.url = "github:tpoechtrager/osxcross";
+    macos-sdk-archive = {
+      url = "file:///path/to/MacOSX14.5.sdk.tar.xz";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, osxcross }: let
+  outputs = { self, nixpkgs, osxcross, macos-sdk-archive }: let
     system = "x86_64-linux";
     pkgs = nixpkgs.legacyPackages.${system};
 
-    # Build the toolchain with your SDK
+    # Realize the SDK once, then share this ref across toolchains.
+    macosSdk = osxcross.lib.${system}.mkMacosSdk {
+      sdkArchive = macos-sdk-archive;
+      sdkVersion = "14.5";
+      # Optional but recommended once known:
+      # outputHash = "sha256-...";
+    };
+
+    # Build the toolchain with a pure SDK ref.
     toolchain = osxcross.lib.${system}.mkOsxcross {
-      sdkPath = ./path/to/MacOSX14.5.sdk.tar.xz;
-      # Optional: explicitly set version if filename doesn't include it
-      # sdkVersion = "14.5";
+      inherit macosSdk;
     };
   in {
     # Use the toolchain in your builds
@@ -37,7 +47,7 @@ A Nix flake for building macOS cross-compilation toolchains on Linux.
 ### Command Line Usage
 
 ```bash
-# Build with explicit SDK path and version
+# Legacy local host path usage, for bootstrapping only.
 nix build --impure --expr '
   let
     flake = builtins.getFlake (toString ./.);
@@ -55,12 +65,31 @@ nix build --impure --expr '
 
 ## Configuration Options
 
+### `mkMacosSdk` Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sdkArchive` | path | Yes | Path/store object for a packaged macOS SDK archive (`.tar`, `.tar.xz`, `.tar.gz`, `.tar.bz2`) |
+| `sdkVersion` | string | No | SDK version (auto-detected from archive filename if not provided) |
+| `outputHash` | string | No | Optional fixed-output hash for stable SDK sharing across flakes/checkouts |
+
+Returns a macOS SDK ref: `{ sdk, sdkRoot, sdkVersion, _type = "osxcross-macos-sdk"; }`.
+
+### `mkMacosSdkRef` Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sdk` | path/derivation | Yes | Already-realized SDK parent output |
+| `sdkVersion` | string | Yes | SDK version |
+| `sdkRoot` | path/string | No | Defaults to `"${sdk}/MacOSX${sdkVersion}.sdk"` |
+
 ### `mkOsxcross` Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `sdkPath` | path | Yes | Path to macOS SDK tarball (`.tar`, `.tar.xz`, `.tar.gz`, `.tar.bz2`) |
-| `sdkVersion` | string | No | SDK version (auto-detected from filename if not provided) |
+| `macosSdk` | attrset | Preferred | SDK ref from `mkMacosSdk` or `mkMacosSdkRef` |
+| `sdkPath` | path | No | Legacy path to macOS SDK archive; builds an SDK ref internally |
+| `sdkVersion` | string | No | SDK version override; must match `macosSdk.sdkVersion` when `macosSdk` is provided |
 | `osxVersionMin` | string | No | Minimum macOS deployment target (default: SDK's minimum) |
 | `enableArchs` | list | No | Architectures to enable (default: all supported by SDK) |
 | `enableLTO` | bool | No | Enable LTO support (default: `true`) |
@@ -68,32 +97,38 @@ nix build --impure --expr '
 ### Example Configurations
 
 ```nix
-# Minimal - auto-detect everything from SDK filename
-toolchain = mkOsxcross {
-  sdkPath = ./MacOSX14.5.sdk.tar.xz;
+# Preferred: realize the SDK once and pass the ref to every toolchain.
+macosSdk = mkMacosSdk {
+  sdkArchive = inputs.macos-sdk-archive;
+  sdkVersion = "14.5";
+  outputHash = "sha256-...";
 };
 
-# Explicit version (useful if filename doesn't include version)
 toolchain = mkOsxcross {
-  sdkPath = ./MacOSX.sdk.tar;
+  inherit macosSdk;
+};
+
+# Already-realized SDK parent output.
+macosSdk = mkMacosSdkRef {
+  sdk = inputs.macos-sdk;
   sdkVersion = "14.5";
 };
 
 # Restrict to specific architectures
 toolchain = mkOsxcross {
-  sdkPath = ./MacOSX14.5.sdk.tar.xz;
+  inherit macosSdk;
   enableArchs = [ "arm64" "x86_64" ];  # Exclude arm64e, x86_64h
 };
 
 # Set minimum deployment target
 toolchain = mkOsxcross {
-  sdkPath = ./MacOSX14.5.sdk.tar.xz;
+  inherit macosSdk;
   osxVersionMin = "11.0";  # Require macOS 11+
 };
 
 # Disable LTO (faster builds, larger binaries)
 toolchain = mkOsxcross {
-  sdkPath = ./MacOSX14.5.sdk.tar.xz;
+  inherit macosSdk;
   enableLTO = false;
 };
 ```
@@ -157,18 +192,27 @@ The flake includes helpers for Rust cross-compilation with [rust-overlay](https:
     osxcross.url = "github:tpoechtrager/osxcross";
     rust-overlay.url = "github:oxalica/rust-overlay";
     crane.url = "github:ipetkov/crane";
+    macos-sdk-archive = {
+      url = "file:///path/to/MacOSX14.5.sdk.tar.xz";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, osxcross, rust-overlay, crane }: let
+  outputs = { self, nixpkgs, osxcross, rust-overlay, crane, macos-sdk-archive }: let
     system = "x86_64-linux";
     pkgs = import nixpkgs {
       inherit system;
       overlays = [ rust-overlay.overlays.default ];
     };
 
+    macosSdk = osxcross.lib.${system}.mkMacosSdk {
+      sdkArchive = macos-sdk-archive;
+      sdkVersion = "14.5";
+    };
+
     # Build osxcross toolchain
     toolchain = osxcross.lib.${system}.mkOsxcross {
-      sdkPath = ./MacOSX14.5.sdk.tar.xz;
+      inherit macosSdk;
     };
 
     # Get Rust helpers
@@ -217,7 +261,8 @@ Common environment variables for cross-compilation.
 rustHelpers.commonEnv
 # => {
 #   OSXCROSS_TARGET_DIR = "/nix/store/...";
-#   OSXCROSS_SDK = "/nix/store/.../SDK/MacOSX.sdk";
+#   OSXCROSS_SDK = "/nix/store/...-macosx-sdk-14.5/MacOSX14.5.sdk";
+#   OSXCROSS_SDKROOT = "/nix/store/...-macosx-sdk-14.5/MacOSX14.5.sdk";
 #   MACOSX_DEPLOYMENT_TARGET = "10.13";
 # }
 ```
@@ -363,6 +408,8 @@ cmake -DCMAKE_TOOLCHAIN_FILE=./result/share/osxcross/toolchain.cmake ...
 - `packages.<system>.default` - Help message (SDK required for full toolchain)
 
 ### Library Functions
+- `lib.<system>.mkMacosSdk` - Realize a canonical SDK store output from an SDK archive
+- `lib.<system>.mkMacosSdkRef` - Reference an already-realized SDK store output
 - `lib.<system>.mkOsxcross` - Build complete toolchain
 - `lib.<system>.mkRustHelpers` - Get Rust cross-compilation helpers
 - `lib.<system>.osxcrossLib` - Low-level helper functions
@@ -371,7 +418,7 @@ cmake -DCMAKE_TOOLCHAIN_FILE=./result/share/osxcross/toolchain.cmake ...
 - `devShells.<system>.default` - Development environment for working on osxcross
 
 ### Overlays
-- `overlays.default` - Nixpkgs overlay adding `mkOsxcross` and `mkRustHelpers`
+- `overlays.default` - Nixpkgs overlay adding the osxcross SDK, toolchain, and Rust helper APIs
 
 ## Toolchain Passthru Attributes
 
@@ -385,7 +432,8 @@ toolchain.primaryArch         # "arm64"
 toolchain.effectiveOsxVersionMin  # "10.13"
 
 # Sub-derivations
-toolchain.sdk          # The extracted SDK
+toolchain.sdk          # The shared SDK parent output
+toolchain.sdkRoot      # The canonical SDK root, e.g. /nix/store/.../MacOSX14.5.sdk
 toolchain.cctools-port # Apple cctools
 toolchain.wrapper      # Compiler wrapper
 toolchain.xar          # XAR tool

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,464 @@
+# OSXCross Nix Flake
+
+A Nix flake for building macOS cross-compilation toolchains on Linux.
+
+## Quick Start
+
+### Building the Toolchain
+
+```nix
+# flake.nix in your project
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    osxcross.url = "github:tpoechtrager/osxcross";
+  };
+
+  outputs = { self, nixpkgs, osxcross }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+
+    # Build the toolchain with your SDK
+    toolchain = osxcross.lib.${system}.mkOsxcross {
+      sdkPath = ./path/to/MacOSX14.5.sdk.tar.xz;
+      # Optional: explicitly set version if filename doesn't include it
+      # sdkVersion = "14.5";
+    };
+  in {
+    # Use the toolchain in your builds
+    packages.${system}.myApp = pkgs.stdenv.mkDerivation {
+      # ...
+      nativeBuildInputs = [ toolchain ];
+    };
+  };
+}
+```
+
+### Command Line Usage
+
+```bash
+# Build with explicit SDK path and version
+nix build --impure --expr '
+  let
+    flake = builtins.getFlake (toString ./.);
+    toolchain = flake.lib.x86_64-linux.mkOsxcross {
+      sdkPath = /path/to/MacOSX14.5.sdk.tar.xz;
+      sdkVersion = "14.5";
+    };
+  in toolchain
+'
+
+# Use the toolchain
+./result/bin/arm64-apple-darwin23-clang -o hello hello.c
+./result/bin/x86_64-apple-darwin23-clang -o hello_x86 hello.c
+```
+
+## Configuration Options
+
+### `mkOsxcross` Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sdkPath` | path | Yes | Path to macOS SDK tarball (`.tar`, `.tar.xz`, `.tar.gz`, `.tar.bz2`) |
+| `sdkVersion` | string | No | SDK version (auto-detected from filename if not provided) |
+| `osxVersionMin` | string | No | Minimum macOS deployment target (default: SDK's minimum) |
+| `enableArchs` | list | No | Architectures to enable (default: all supported by SDK) |
+| `enableLTO` | bool | No | Enable LTO support (default: `true`) |
+
+### Example Configurations
+
+```nix
+# Minimal - auto-detect everything from SDK filename
+toolchain = mkOsxcross {
+  sdkPath = ./MacOSX14.5.sdk.tar.xz;
+};
+
+# Explicit version (useful if filename doesn't include version)
+toolchain = mkOsxcross {
+  sdkPath = ./MacOSX.sdk.tar;
+  sdkVersion = "14.5";
+};
+
+# Restrict to specific architectures
+toolchain = mkOsxcross {
+  sdkPath = ./MacOSX14.5.sdk.tar.xz;
+  enableArchs = [ "arm64" "x86_64" ];  # Exclude arm64e, x86_64h
+};
+
+# Set minimum deployment target
+toolchain = mkOsxcross {
+  sdkPath = ./MacOSX14.5.sdk.tar.xz;
+  osxVersionMin = "11.0";  # Require macOS 11+
+};
+
+# Disable LTO (faster builds, larger binaries)
+toolchain = mkOsxcross {
+  sdkPath = ./MacOSX14.5.sdk.tar.xz;
+  enableLTO = false;
+};
+```
+
+## Available Tools
+
+The toolchain provides these binaries (prefixed with `<arch>-apple-darwin<version>-`):
+
+### Compilers
+- `clang`, `clang++` - C/C++ compilers
+- `cc`, `c++` - Aliases for clang/clang++
+
+### Linker & Object Tools
+- `ld` - Apple's ld64 linker
+- `ar` - Archive tool
+- `ranlib` - Archive index generator
+- `libtool` - Library tool
+- `lipo` - Universal binary creator
+- `nm` - Symbol table viewer
+- `otool` - Object file viewer
+- `strip` - Symbol stripper
+- `install_name_tool` - Dynamic library path editor
+
+### Utilities
+- `dsymutil` - Debug symbol utility
+- `codesign_allocate` - Code signing space allocator
+- `vtool` - Version tool
+- `xcrun` - Xcode tool runner (simulated)
+- `sw_vers` - macOS version info (simulated)
+- `pkg-config` - Package configuration tool (arch-prefixed only, see note below)
+
+### Shortcut Prefixes
+For convenience, short prefixes are available:
+- `o64-clang` → `x86_64-apple-darwin*-clang`
+- `oa64-clang` → `arm64-apple-darwin*-clang`
+- `o32-clang` → `i386-apple-darwin*-clang` (SDK ≤10.13 only)
+
+### Tool Categories
+
+The flake organizes tools into categories that determine how symlinks are created:
+
+| Category | Unprefixed | Arch-prefixed | Shortcuts | Example |
+|----------|------------|---------------|-----------|---------|
+| Compiler wrappers | No | Yes | Yes | `clang`, `clang++` |
+| Utility tools | Yes | Yes | No | `osxcross`, `xcrun` |
+| Arch-only tools | No | Yes | No | `pkg-config` |
+| cctools binaries | Yes (common) | Yes | No | `ar`, `ld`, `lipo` |
+
+**Note on pkg-config**: The `pkg-config` wrapper is only available with architecture prefixes (e.g., `arm64-apple-darwin23-pkg-config`) to avoid shadowing the system's `pkg-config` during native Linux builds. This prevents issues when building projects that require both native and cross-compiled dependencies.
+
+## Rust Cross-Compilation
+
+The flake includes helpers for Rust cross-compilation with [rust-overlay](https://github.com/oxalica/rust-overlay) and [crane](https://github.com/ipetkov/crane).
+
+### Setup
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    osxcross.url = "github:tpoechtrager/osxcross";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs = { self, nixpkgs, osxcross, rust-overlay, crane }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {
+      inherit system;
+      overlays = [ rust-overlay.overlays.default ];
+    };
+
+    # Build osxcross toolchain
+    toolchain = osxcross.lib.${system}.mkOsxcross {
+      sdkPath = ./MacOSX14.5.sdk.tar.xz;
+    };
+
+    # Get Rust helpers
+    rustHelpers = osxcross.lib.${system}.mkRustHelpers toolchain;
+
+    # Setup Rust with macOS targets
+    rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+      targets = rustHelpers.rustTargets;  # ["aarch64-apple-darwin" "x86_64-apple-darwin"]
+    };
+
+    craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+  in {
+    # ... see examples below
+  };
+}
+```
+
+### Rust Helper Functions
+
+#### `rustTargets`
+List of Rust target triples supported by the toolchain.
+```nix
+rustHelpers.rustTargets
+# => ["aarch64-apple-darwin" "x86_64-apple-darwin"]
+```
+
+#### `cargoEnvFor`
+Environment variables for a specific target.
+```nix
+rustHelpers.cargoEnvFor "aarch64-apple-darwin"
+# => {
+#   CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER = "/nix/store/.../bin/arm64-apple-darwin23-clang";
+#   CARGO_TARGET_AARCH64_APPLE_DARWIN_AR = "/nix/store/.../bin/arm64-apple-darwin23-ar";
+#   CC_aarch64_apple_darwin = "/nix/store/.../bin/arm64-apple-darwin23-clang";
+#   CXX_aarch64_apple_darwin = "/nix/store/.../bin/arm64-apple-darwin23-clang++";
+#   AR_aarch64_apple_darwin = "/nix/store/.../bin/arm64-apple-darwin23-ar";
+# }
+```
+
+#### `cargoEnvAll`
+Environment variables for all supported targets.
+
+#### `commonEnv`
+Common environment variables for cross-compilation.
+```nix
+rustHelpers.commonEnv
+# => {
+#   OSXCROSS_TARGET_DIR = "/nix/store/...";
+#   OSXCROSS_SDK = "/nix/store/.../SDK/MacOSX.sdk";
+#   MACOSX_DEPLOYMENT_TARGET = "10.13";
+# }
+```
+
+#### `mkCargoConfig`
+Generate `.cargo/config.toml` content.
+```nix
+rustHelpers.mkCargoConfig { }
+# => "[target.aarch64-apple-darwin]\nlinker = \"...\"\n..."
+
+# With custom deployment target
+rustHelpers.mkCargoConfig { deploymentTarget = "11.0"; }
+```
+
+#### `writeCargoConfig`
+Write cargo config to a file in the Nix store.
+```nix
+rustHelpers.writeCargoConfig { }
+# => /nix/store/...-cargo-config.toml
+```
+
+#### `mkCrossBuilder`
+Wrap crane for cross-compilation.
+```nix
+let
+  darwinBuilder = rustHelpers.mkCrossBuilder {
+    inherit craneLib;
+    target = "aarch64-apple-darwin";
+  };
+in
+  darwinBuilder.buildPackage {
+    src = ./.;
+    # ... other crane options
+  }
+```
+
+#### `mkUniversalBinary`
+Create universal (fat) binaries from arm64 + x86_64 builds.
+```nix
+rustHelpers.mkUniversalBinary {
+  name = "myapp";
+  arm64Drv = arm64Build;
+  x86_64Drv = x86Build;
+  binaries = [ "myapp" "myapp-cli" ];  # Optional, defaults to [name]
+}
+```
+
+#### `mkUniversalLibrary`
+Create universal libraries.
+```nix
+rustHelpers.mkUniversalLibrary {
+  name = "mylib";
+  arm64Drv = arm64Build;
+  x86_64Drv = x86Build;
+  libraries = [ "libmylib.a" "libmylib.dylib" ];  # Optional
+}
+```
+
+#### `mkDevShellHook`
+Shell hook for development environments.
+```nix
+devShells.default = pkgs.mkShell {
+  shellHook = rustHelpers.mkDevShellHook { };
+};
+```
+
+### Complete Rust Example
+
+```nix
+{
+  packages.${system} = {
+    # ARM64 build
+    myapp-aarch64 = let
+      builder = rustHelpers.mkCrossBuilder {
+        inherit craneLib;
+        target = "aarch64-apple-darwin";
+      };
+    in builder.buildPackage {
+      src = ./.;
+      cargoExtraArgs = "--release";
+    };
+
+    # x86_64 build
+    myapp-x86_64 = let
+      builder = rustHelpers.mkCrossBuilder {
+        inherit craneLib;
+        target = "x86_64-apple-darwin";
+      };
+    in builder.buildPackage {
+      src = ./.;
+      cargoExtraArgs = "--release";
+    };
+
+    # Universal binary
+    myapp-universal = rustHelpers.mkUniversalBinary {
+      name = "myapp";
+      arm64Drv = self.packages.${system}.myapp-aarch64;
+      x86_64Drv = self.packages.${system}.myapp-x86_64;
+    };
+  };
+
+  devShells.${system}.default = pkgs.mkShell {
+    nativeBuildInputs = [ rustToolchain toolchain ];
+    shellHook = rustHelpers.mkDevShellHook { };
+  };
+}
+```
+
+## CMake Integration
+
+The toolchain includes CMake integration via a toolchain file.
+
+```bash
+# Using the cmake wrapper
+./result/bin/osxcross-cmake -B build -S .
+
+# Or with architecture-specific wrapper
+./result/bin/arm64-apple-darwin23-cmake -B build -S .
+
+# Manual toolchain file usage
+cmake -DCMAKE_TOOLCHAIN_FILE=./result/share/osxcross/toolchain.cmake ...
+```
+
+## Supported SDK Versions
+
+| SDK Version | Darwin Target | Architectures | TAPI Required |
+|-------------|---------------|---------------|---------------|
+| 10.6 - 10.10 | darwin10-14 | i386, x86_64 | No |
+| 10.11 - 10.13 | darwin15-17 | i386, x86_64, x86_64h | Yes |
+| 10.14 - 10.15 | darwin18-19 | x86_64, x86_64h | Yes |
+| 11.x | darwin20.x | arm64, arm64e, x86_64, x86_64h | Yes |
+| 12.x | darwin21.x | arm64, arm64e, x86_64, x86_64h | Yes |
+| 13.x | darwin22.x | arm64, arm64e, x86_64, x86_64h | Yes |
+| 14.x | darwin23.x | arm64, arm64e, x86_64, x86_64h | Yes |
+| 15.x | darwin24.x | arm64, arm64e, x86_64, x86_64h | Yes |
+| 26.x | darwin25.x | arm64, arm64e, x86_64, x86_64h | Yes |
+
+## Flake Outputs
+
+### Packages
+- `packages.<system>.xar` - XAR archive tool
+- `packages.<system>.apple-libtapi` - Apple TAPI library
+- `packages.<system>.default` - Help message (SDK required for full toolchain)
+
+### Library Functions
+- `lib.<system>.mkOsxcross` - Build complete toolchain
+- `lib.<system>.mkRustHelpers` - Get Rust cross-compilation helpers
+- `lib.<system>.osxcrossLib` - Low-level helper functions
+
+### Dev Shells
+- `devShells.<system>.default` - Development environment for working on osxcross
+
+### Overlays
+- `overlays.default` - Nixpkgs overlay adding `mkOsxcross` and `mkRustHelpers`
+
+## Toolchain Passthru Attributes
+
+The built toolchain exposes useful attributes via `passthru`:
+
+```nix
+toolchain.detectedSdkVersion  # "14.5"
+toolchain.darwinTarget        # "darwin23.5"
+toolchain.supportedArchs      # ["arm64" "arm64e" "x86_64" "x86_64h"]
+toolchain.primaryArch         # "arm64"
+toolchain.effectiveOsxVersionMin  # "10.13"
+
+# Sub-derivations
+toolchain.sdk          # The extracted SDK
+toolchain.cctools-port # Apple cctools
+toolchain.wrapper      # Compiler wrapper
+toolchain.xar          # XAR tool
+toolchain.apple-libtapi  # TAPI library (if needed)
+
+# Helper functions
+toolchain.getCompiler "arm64"     # Path to arm64 clang
+toolchain.getCompilerCxx "arm64"  # Path to arm64 clang++
+toolchain.getAr "arm64"           # Path to arm64 ar
+toolchain.getLd "arm64"           # Path to arm64 ld
+```
+
+## Obtaining an SDK
+
+macOS SDKs can be extracted from Xcode using the included script:
+
+```bash
+# On a Mac with Xcode installed
+./tools/gen_sdk_package.sh
+
+# Or from an Xcode .xip file
+./tools/gen_sdk_package_pbzx.sh /path/to/Xcode.xip
+```
+
+The SDK tarball will be created in the `tarballs/` directory.
+
+## Troubleshooting
+
+### "cannot find clang intrinsic headers"
+This warning is normal when using the host system's clang. It doesn't affect functionality.
+
+### "Your clang installation is outdated"
+This warning appears with very new SDKs and older version parsing. It's cosmetic and doesn't affect functionality.
+
+### Linker errors about "unrecognised emulation mode"
+Ensure you're using the osxcross-provided clang wrappers, not the system clang directly.
+
+### SDK not found
+Make sure:
+1. The SDK tarball exists at the specified path
+2. If the filename doesn't include the version (e.g., `MacOSX.sdk.tar`), provide `sdkVersion` explicitly
+3. The tarball contains a directory named `MacOSX.sdk` or `MacOSX<version>.sdk`
+
+### pkg-config not finding packages during cross-compilation
+Use the architecture-prefixed pkg-config:
+```bash
+# Instead of: pkg-config --libs mylib
+arm64-apple-darwin23-pkg-config --libs mylib
+```
+
+Set `OSXCROSS_PKG_CONFIG_PATH` to point to your MacPorts or cross-compiled library `.pc` files.
+
+### Native Linux builds fail with "wayland-client not found" or similar
+If osxcross is in your PATH and native builds fail to find system libraries, this is likely because the system's `pkg-config` is being shadowed. The Nix flake avoids creating an unprefixed `pkg-config` symlink to prevent this. If you're using a manual osxcross installation, ensure you use architecture-prefixed pkg-config for cross-compilation only.
+
+## Architecture
+
+The Nix flake is organized into these components:
+
+```
+nix/
+├── lib.nix          # Helper functions (SDK detection, symlink generation)
+├── osxcross.nix     # Main derivation combining all components
+├── sdk.nix          # SDK extraction
+├── cctools-port.nix # Apple cctools (ar, ld, lipo, etc.)
+├── wrapper.nix      # Compiler wrapper
+├── xar.nix          # XAR archive tool
+├── apple-libtapi.nix # TAPI library for .tbd files
+└── rust.nix         # Rust cross-compilation helpers
+```
+
+## License
+
+- OSXCross: GPL-2.0-or-later
+- cctools-port: APSL-2.0
+- Apple TAPI: Apache-2.0 with LLVM exception

--- a/nix/README.md
+++ b/nix/README.md
@@ -4,7 +4,12 @@ A Nix flake for building macOS cross-compilation toolchains on Linux.
 
 ## Quick Start
 
-### One-Time SDK Realization
+### SDK Utilities
+
+osxcross is intentionally policy-light: `mkOsxcross` accepts an already
+resolved SDK ref. The archive realization helper is available for consumers
+that want to build that ref from an archive, but higher-level flakes may choose
+their own SDK discovery and validation workflow.
 
 To bootstrap a stable SDK store path from a host-local archive:
 
@@ -59,25 +64,6 @@ echo "$STORE_PATH"
 }
 ```
 
-### Command Line Usage
-
-```bash
-# Legacy local host path usage, for bootstrapping only.
-nix build --impure --expr '
-  let
-    flake = builtins.getFlake (toString ./.);
-    toolchain = flake.lib.x86_64-linux.mkOsxcross {
-      sdkPath = /path/to/MacOSX14.5.sdk.tar.xz;
-      sdkVersion = "14.5";
-    };
-  in toolchain
-'
-
-# Use the toolchain
-./result/bin/arm64-apple-darwin23-clang -o hello hello.c
-./result/bin/x86_64-apple-darwin23-clang -o hello_x86 hello.c
-```
-
 ## Configuration Options
 
 ### `mkMacosSdk` Parameters
@@ -94,16 +80,15 @@ Returns a macOS SDK ref: `{ sdk, sdkRoot, sdkVersion, _type = "osxcross-macos-sd
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `sdk` | path/derivation | Yes | Already-realized SDK parent output |
+| `sdk` | path/derivation | Yes | Already-realized SDK parent output, or the SDK root itself when `sdkRoot` is also provided |
 | `sdkVersion` | string | Yes | SDK version |
-| `sdkRoot` | path/string | No | Defaults to `"${sdk}/MacOSX${sdkVersion}.sdk"` |
+| `sdkRoot` | path/string | No | Defaults to `"${sdk}/MacOSX${sdkVersion}.sdk"`; may point directly at `/path/to/MacOSX${sdkVersion}.sdk` |
 
 ### `mkOsxcross` Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `macosSdk` | attrset | Preferred | SDK ref from `mkMacosSdk` or `mkMacosSdkRef` |
-| `sdkPath` | path | No | Legacy path to macOS SDK archive; builds an SDK ref internally |
+| `macosSdk` | attrset | Yes | SDK ref from `mkMacosSdk` or `mkMacosSdkRef` |
 | `sdkVersion` | string | No | SDK version override; must match `macosSdk.sdkVersion` when `macosSdk` is provided |
 | `osxVersionMin` | string | No | Minimum macOS deployment target (default: SDK's minimum) |
 | `enableArchs` | list | No | Architectures to enable (default: all supported by SDK) |
@@ -126,6 +111,13 @@ toolchain = mkOsxcross {
 # Already-realized SDK parent output.
 macosSdk = mkMacosSdkRef {
   sdk = inputs.macos-sdk;
+  sdkVersion = "14.5";
+};
+
+# Direct SDK root.
+macosSdk = mkMacosSdkRef {
+  sdk = /nix/store/...-MacOSX14.5.sdk;
+  sdkRoot = /nix/store/...-MacOSX14.5.sdk;
   sdkVersion = "14.5";
 };
 
@@ -423,8 +415,8 @@ cmake -DCMAKE_TOOLCHAIN_FILE=./result/share/osxcross/toolchain.cmake ...
 - `packages.<system>.default` - Help message (SDK required for full toolchain)
 
 ### Library Functions
-- `lib.<system>.mkMacosSdk` - Realize a canonical SDK store output from an SDK archive
-- `lib.<system>.mkMacosSdkRef` - Reference an already-realized SDK store output
+- `lib.<system>.mkMacosSdk` - Utility to realize a canonical SDK store output from an SDK archive
+- `lib.<system>.mkMacosSdkRef` - Reference an already-realized SDK store output or direct SDK root
 - `lib.<system>.mkOsxcross` - Build complete toolchain
 - `lib.<system>.mkRustHelpers` - Get Rust cross-compilation helpers
 - `lib.<system>.osxcrossLib` - Low-level helper functions

--- a/nix/README.md
+++ b/nix/README.md
@@ -4,6 +4,21 @@ A Nix flake for building macOS cross-compilation toolchains on Linux.
 
 ## Quick Start
 
+### One-Time SDK Realization
+
+To bootstrap a stable SDK store path from a host-local archive:
+
+```bash
+nix run .#realize-macos-sdk -- /path/to/MacOSX14.5.sdk.tar.xz 14.5
+```
+
+For scripting, use shell-friendly output:
+
+```bash
+eval "$(nix run .#realize-macos-sdk -- --env /path/to/MacOSX14.5.sdk.tar.xz 14.5)"
+echo "$STORE_PATH"
+```
+
 ### Building the Toolchain
 
 ```nix

--- a/nix/apple-libtapi.nix
+++ b/nix/apple-libtapi.nix
@@ -1,0 +1,80 @@
+# Apple TAPI library
+# Required for SDK >= 10.11 to handle text-based API stubs (.tbd files)
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  python3,
+  bash,
+  coreutils,
+  gnugrep,
+  gnused,
+  llvmPackages,
+}:
+stdenv.mkDerivation rec {
+  pname = "apple-libtapi";
+  version = "1600.0.11.8";
+
+  src = fetchFromGitHub {
+    owner = "tpoechtrager";
+    repo = "apple-libtapi";
+    # Latest commit with stdint.h fixes for modern compilers
+    rev = "aed9334283e3e290bba622ee980bde2322e4d516";
+    hash = "sha256-+iuZ8hbH/2yWF+Km4ktXyjRcofxYMPxe43IGp8WdTog=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+    bash
+    coreutils
+    gnugrep
+    gnused
+    llvmPackages.clang
+  ];
+
+  buildInputs = [
+    llvmPackages.llvm
+    llvmPackages.libclang
+  ];
+
+  # Patch shebangs in all scripts
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  # Use the project's build.sh but with proper environment
+  dontUseCmakeConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    export INSTALLPREFIX=$out
+    export CC="${llvmPackages.clang}/bin/clang"
+    export CXX="${llvmPackages.clang}/bin/clang++"
+
+    # Run the project's build script
+    bash ./build.sh
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    bash ./install.sh
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Apple's TAPI library for handling .tbd stub files";
+    homepage = "https://github.com/tpoechtrager/apple-libtapi";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = [];
+  };
+}

--- a/nix/cctools-port.nix
+++ b/nix/cctools-port.nix
@@ -1,0 +1,140 @@
+# cctools-port - Apple's cctools and ld64 for Linux
+# Provides: ar, as, ld, lipo, nm, otool, ranlib, strip, etc.
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  llvmPackages,
+  libuuid,
+  xar,
+  apple-libtapi ? null,
+  darwinTarget,
+  primaryArch,
+  enableLTO ? true,
+}:
+stdenv.mkDerivation rec {
+  pname = "cctools-port";
+  version = "1010.6-ld64-951.9";
+
+  src = fetchFromGitHub {
+    owner = "tpoechtrager";
+    repo = "cctools-port";
+    rev = "e79d784d667816e4b15a0abd78828f9abb0a0b99";
+    hash = "sha256-5VCNJrRQH5zAsYZQ/PEa82HfK/twULGucF/wHQKQDJM=";
+  };
+
+  sourceRoot = "${src.name}/cctools";
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    llvmPackages.clang
+  ];
+
+  buildInputs =
+    [
+      llvmPackages.llvm
+      llvmPackages.libclang
+      libuuid
+      xar
+    ]
+    ++ lib.optional (apple-libtapi != null) apple-libtapi;
+
+  # Patches for compatibility with modern LLVM and libtapi 1600+
+  postPatch = ''
+        # Add clone() method to BlobCore class (missing in newer LLVM)
+        substituteInPlace ld64/src/ld/code-sign-blobs/blob.h \
+          --replace-fail \
+            'static BlobCore *readBlob(int fd)			{ return readBlob(fd, 0, 0, 0); }' \
+            'static BlobCore *readBlob(int fd)			{ return readBlob(fd, 0, 0, 0); }
+
+    	BlobCore *clone() const {
+    		size_t len = length();
+    		BlobCore *copy = (BlobCore *)malloc(len);
+    		memcpy(copy, this, len);
+    		return copy;
+    	}'
+
+        # Fix tapi::Platform compatibility for libtapi 1600+
+        # The new API uses getPlatformSet() returning uint32_t values instead of tapi::Platform enum
+        # Remove the old mapPlatform function and the getPlatform() fallback code
+        # The new code path already handles this with getPlatformSet()
+
+        # Remove the mapPlatform function entirely (not needed with new API)
+        sed -i '/^static ld::VersionSet mapPlatform/,/^}$/d' ld64/src/ld/parsers/textstub_dylib_file.cpp
+
+        # Remove the TAPI version check and always use the new getPlatformSet() path
+        # Replace the conditional block with just the new API code
+        substituteInPlace ld64/src/ld/parsers/textstub_dylib_file.cpp \
+          --replace-fail \
+    '#if ((TAPI_API_VERSION_MAJOR == 1 &&  TAPI_API_VERSION_MINOR >= 6) || (TAPI_API_VERSION_MAJOR > 1))
+    	if (tapi::APIVersion::isAtLeast(1, 6)) {
+    		for (const auto &platform : file->getPlatformSet())
+    			lcPlatforms.insert((ld::Platform)platform);
+    	} else
+    #endif
+    	{
+    		lcPlatforms = mapPlatform(file->getPlatform(), useSimulatorVariant());
+    	}' \
+          'for (const auto &platform : file->getPlatformSet())
+    		lcPlatforms.insert((ld::Platform)platform);'
+  '';
+
+  configureFlags =
+    [
+      "--target=${primaryArch}-apple-${darwinTarget}"
+      "--with-llvm-config=${llvmPackages.llvm.dev}/bin/llvm-config"
+      "--with-libxar=${xar}"
+    ]
+    ++ lib.optional (apple-libtapi != null) "--with-libtapi=${apple-libtapi}"
+    ++ lib.optional (!enableLTO) "--disable-lto-support";
+
+  # Ensure we use clang (required by cctools-port)
+  preConfigure = ''
+    export CC="${llvmPackages.clang}/bin/clang"
+    export CXX="${llvmPackages.clang}/bin/clang++"
+  '';
+
+  # Ensure we can find LLVM headers
+  env = {
+    NIX_CFLAGS_COMPILE = toString [
+      "-I${llvmPackages.llvm.dev}/include"
+      "-I${llvmPackages.libclang.dev}/include"
+    ];
+    NIX_LDFLAGS = toString [
+      "-L${llvmPackages.llvm.lib}/lib"
+    ];
+  };
+
+  # Don't strip - we need debug symbols for some tools
+  dontStrip = true;
+
+  # Tools to create unprefixed symlinks for
+  passthru.commonTools = ["ar" "as" "nm" "otool" "ranlib" "strip" "libtool" "install_name_tool" "lipo"];
+
+  postInstall = let
+    # Tools to symlink without arch prefix
+    commonTools = ["ar" "as" "nm" "otool" "ranlib" "strip" "libtool" "install_name_tool" "lipo"];
+    # Generate symlink commands
+    symlinkCommands =
+      lib.concatMapStringsSep "\n" (tool: ''
+        if [ -f "$out/bin/${primaryArch}-apple-${darwinTarget}-${tool}" ]; then
+          ln -sf "${primaryArch}-apple-${darwinTarget}-${tool}" "$out/bin/${tool}"
+        fi
+      '')
+      commonTools;
+  in ''
+    # Create convenience symlinks for common tools without arch prefix
+    ${symlinkCommands}
+  '';
+
+  meta = with lib; {
+    description = "Apple cctools and ld64 for Linux (and other platforms)";
+    homepage = "https://github.com/tpoechtrager/cctools-port";
+    license = licenses.apsl20;
+    platforms = platforms.unix;
+    maintainers = [];
+  };
+}

--- a/nix/cctools-port.nix
+++ b/nix/cctools-port.nix
@@ -44,6 +44,15 @@ stdenv.mkDerivation rec {
 
   # Patches for compatibility with modern LLVM and libtapi 1600+
   postPatch = ''
+        # Newer libtool no longer infers a tag for Objective-C sources here.
+        # cctools builds them with clang as C-family objects, so tag them as CC.
+        substituteInPlace libobjc2/Makefile.am \
+          --replace-fail \
+            'libobjc_la_CPPFLAGS=' \
+            'AM_LIBTOOLFLAGS = --tag=CC
+
+    libobjc_la_CPPFLAGS='
+
         # Add clone() method to BlobCore class (missing in newer LLVM)
         substituteInPlace ld64/src/ld/code-sign-blobs/blob.h \
           --replace-fail \
@@ -95,6 +104,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     export CC="${llvmPackages.clang}/bin/clang"
     export CXX="${llvmPackages.clang}/bin/clang++"
+    export CFLAGS="-std=gnu17"
   '';
 
   # Ensure we can find LLVM headers

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -5,7 +5,6 @@
 #
 # Usage:
 #   nix develop            # Enter the dev shell (uses flake.nix devShells.default)
-#   nix develop .#dev      # Explicit dev shell entry
 #
 # Formatting:
 #   This project uses Alejandra for Nix code formatting.
@@ -15,16 +14,19 @@
 #     alejandra .
 #
 #   To format specific files:
-#     alejandra flake.nix devshell.nix
+#     alejandra flake.nix nix/devshell.nix
 #
 #   To check formatting without modifying (useful for CI):
 #     alejandra --check .
 #
 #   Alejandra docs: https://github.com/kamadorueda/alejandra
 #
-{pkgs ? import <nixpkgs> {}}: let
-  # Build dependencies for OSXCross
-  buildDeps = with pkgs; [
+{pkgs}:
+pkgs.mkShell {
+  name = "osxcross-dev";
+
+  packages = with pkgs; [
+    # Build tools
     clang
     llvmPackages.llvm
     cmake
@@ -33,10 +35,8 @@
     automake
     libtool
     pkg-config
-  ];
 
-  # Runtime dependencies
-  runtimeDeps = with pkgs; [
+    # Required dependencies
     git
     gnupatch
     python3
@@ -48,46 +48,33 @@
     zlib
     bash
     libuuid
-  ];
 
-  # Optional utilities
-  utilityDeps = with pkgs; [
+    # Utilities
     curl
     wget
-  ];
 
-  # Development and formatting tools
-  devTools = with pkgs; [
     # Nix formatting - Alejandra is an opinionated Nix formatter
     # Usage: alejandra .          (format all nix files)
     #        alejandra --check .  (check without modifying)
     alejandra
 
-    # Testing
+    # Testing (bats for wrapper unit tests)
     bats
   ];
-in
-  pkgs.mkShell {
-    name = "osxcross-dev";
 
-    buildInputs = buildDeps ++ runtimeDeps ++ utilityDeps ++ devTools;
-
-    shellHook = ''
-      echo "╔══════════════════════════════════════════════════════════════╗"
-      echo "║          OSXCross Development Environment                    ║"
-      echo "╚══════════════════════════════════════════════════════════════╝"
-      echo ""
-      echo "Build commands:"
-      echo "  ./build.sh              Build toolchain (SDK required in ./tarballs/)"
-      echo "  make -C wrapper/        Build the compiler wrapper"
-      echo "  make -C wrapper/ clean  Clean wrapper build artifacts"
-      echo ""
-      echo "Testing:"
-      echo "  cd wrapper/unittests && ./run.bats"
-      echo ""
-      echo "Nix formatting (Alejandra):"
-      echo "  alejandra .             Format all Nix files"
-      echo "  alejandra --check .     Check formatting without changes"
-      echo ""
-    '';
-  }
+  shellHook = ''
+    echo "OSXCross Development Environment"
+    echo ""
+    echo "Build commands:"
+    echo "  ./build.sh              Build toolchain (SDK required in ./tarballs/)"
+    echo "  make -C wrapper/        Build the compiler wrapper"
+    echo "  make -C wrapper/ clean  Clean wrapper build artifacts"
+    echo ""
+    echo "Testing:"
+    echo "  cd wrapper/unittests && ./run.bats"
+    echo ""
+    echo "Nix formatting (Alejandra):"
+    echo "  alejandra .             Format all Nix files"
+    echo "  alejandra --check .     Check formatting without changes"
+  '';
+}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -21,7 +21,10 @@
 #
 #   Alejandra docs: https://github.com/kamadorueda/alejandra
 #
-{pkgs}:
+{
+  pkgs,
+  sdkShellHook ? "",
+}:
 pkgs.mkShell {
   name = "osxcross-dev";
 
@@ -64,6 +67,8 @@ pkgs.mkShell {
 
   shellHook = ''
     echo "OSXCross Development Environment"
+    echo ""
+    ${sdkShellHook}
     echo ""
     echo "Build commands:"
     echo "  ./build.sh              Build toolchain (SDK required in ./tarballs/)"

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,93 @@
+# Development shell for OSXCross local development
+#
+# This file provides a Nix development environment with all tools needed
+# to work on OSXCross locally.
+#
+# Usage:
+#   nix develop            # Enter the dev shell (uses flake.nix devShells.default)
+#   nix develop .#dev      # Explicit dev shell entry
+#
+# Formatting:
+#   This project uses Alejandra for Nix code formatting.
+#   Alejandra is an opinionated Nix formatter that enforces consistent style.
+#
+#   To format all Nix files:
+#     alejandra .
+#
+#   To format specific files:
+#     alejandra flake.nix devshell.nix
+#
+#   To check formatting without modifying (useful for CI):
+#     alejandra --check .
+#
+#   Alejandra docs: https://github.com/kamadorueda/alejandra
+#
+{pkgs ? import <nixpkgs> {}}: let
+  # Build dependencies for OSXCross
+  buildDeps = with pkgs; [
+    clang
+    llvmPackages.llvm
+    cmake
+    gnumake
+    autoconf
+    automake
+    libtool
+    pkg-config
+  ];
+
+  # Runtime dependencies
+  runtimeDeps = with pkgs; [
+    git
+    gnupatch
+    python3
+    openssl
+    xz
+    libxml2
+    bzip2
+    cpio
+    zlib
+    bash
+    libuuid
+  ];
+
+  # Optional utilities
+  utilityDeps = with pkgs; [
+    curl
+    wget
+  ];
+
+  # Development and formatting tools
+  devTools = with pkgs; [
+    # Nix formatting - Alejandra is an opinionated Nix formatter
+    # Usage: alejandra .          (format all nix files)
+    #        alejandra --check .  (check without modifying)
+    alejandra
+
+    # Testing
+    bats
+  ];
+in
+  pkgs.mkShell {
+    name = "osxcross-dev";
+
+    buildInputs = buildDeps ++ runtimeDeps ++ utilityDeps ++ devTools;
+
+    shellHook = ''
+      echo "╔══════════════════════════════════════════════════════════════╗"
+      echo "║          OSXCross Development Environment                    ║"
+      echo "╚══════════════════════════════════════════════════════════════╝"
+      echo ""
+      echo "Build commands:"
+      echo "  ./build.sh              Build toolchain (SDK required in ./tarballs/)"
+      echo "  make -C wrapper/        Build the compiler wrapper"
+      echo "  make -C wrapper/ clean  Clean wrapper build artifacts"
+      echo ""
+      echo "Testing:"
+      echo "  cd wrapper/unittests && ./run.bats"
+      echo ""
+      echo "Nix formatting (Alejandra):"
+      echo "  alejandra .             Format all Nix files"
+      echo "  alejandra --check .     Check formatting without changes"
+      echo ""
+    '';
+  }

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,546 @@
+# OSXCross Nix Library
+# Helper functions for SDK version detection, architecture mapping, and toolchain configuration
+{lib}: let
+  # SDK version to darwin target mapping (from build.sh)
+  # Maps SDK major.minor version to darwin target info
+  sdkVersionMap = {
+    # Legacy SDKs (i386 support)
+    "10.6" = {
+      target = "darwin10";
+      archs = ["i386" "x86_64"];
+      needsTapi = false;
+      minVersion = "10.6";
+    };
+    "10.7" = {
+      target = "darwin11";
+      archs = ["i386" "x86_64"];
+      needsTapi = false;
+      minVersion = "10.6";
+    };
+    "10.8" = {
+      target = "darwin12";
+      archs = ["i386" "x86_64" "x86_64h"];
+      needsTapi = false;
+      minVersion = "10.6";
+    };
+    "10.9" = {
+      target = "darwin13";
+      archs = ["i386" "x86_64" "x86_64h"];
+      needsTapi = false;
+      minVersion = "10.6";
+    };
+    "10.10" = {
+      target = "darwin14";
+      archs = ["i386" "x86_64" "x86_64h"];
+      needsTapi = false;
+      minVersion = "10.6";
+    };
+    "10.11" = {
+      target = "darwin15";
+      archs = ["i386" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.6";
+    };
+    "10.12" = {
+      target = "darwin16";
+      archs = ["i386" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.6";
+    };
+    "10.13" = {
+      target = "darwin17";
+      archs = ["i386" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.6";
+    };
+
+    # Modern SDKs (no i386, TAPI required)
+    "10.14" = {
+      target = "darwin18";
+      archs = ["x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "10.15" = {
+      target = "darwin19";
+      archs = ["x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+
+    # Big Sur+ (arm64 support)
+    "11" = {
+      target = "darwin20.1";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "11.0" = {
+      target = "darwin20.1";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "11.1" = {
+      target = "darwin20.2";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "11.2" = {
+      target = "darwin20.3";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "11.3" = {
+      target = "darwin20.4";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+
+    # Monterey
+    "12" = {
+      target = "darwin21.1";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "12.0" = {
+      target = "darwin21.1";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "12.1" = {
+      target = "darwin21.2";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "12.2" = {
+      target = "darwin21.3";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "12.3" = {
+      target = "darwin21.4";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+
+    # Ventura
+    "13" = {
+      target = "darwin22.1";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "13.0" = {
+      target = "darwin22.1";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "13.1" = {
+      target = "darwin22.2";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "13.2" = {
+      target = "darwin22.3";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+    "13.3" = {
+      target = "darwin22.4";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.9";
+    };
+
+    # Sonoma
+    "14" = {
+      target = "darwin23";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+    "14.0" = {
+      target = "darwin23";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+    "14.1" = {
+      target = "darwin23.1";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+    "14.2" = {
+      target = "darwin23.2";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+    "14.3" = {
+      target = "darwin23.3";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+    "14.4" = {
+      target = "darwin23.4";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+    "14.5" = {
+      target = "darwin23.5";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+
+    # Sequoia
+    "15" = {
+      target = "darwin24";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+    "15.0" = {
+      target = "darwin24";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+    "15.1" = {
+      target = "darwin24.1";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+    "15.2" = {
+      target = "darwin24.2";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+
+    # macOS 26 (future)
+    "26" = {
+      target = "darwin25";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+    "26.0" = {
+      target = "darwin25";
+      archs = ["arm64" "arm64e" "x86_64" "x86_64h"];
+      needsTapi = true;
+      minVersion = "10.13";
+    };
+  };
+
+  # Detect SDK version from tarball filename
+  # E.g., "MacOSX14.5.sdk.tar.xz" -> "14.5"
+  detectSdkVersion = filename: let
+    # Remove common extensions
+    cleaned = lib.pipe filename [
+      (lib.removeSuffix ".tar.xz")
+      (lib.removeSuffix ".tar.gz")
+      (lib.removeSuffix ".tar.bz2")
+      (lib.removeSuffix ".tar")
+      (lib.removeSuffix ".sdk")
+    ];
+    # Match MacOSX followed by version number
+    match = builtins.match ".*MacOSX([0-9]+\\.?[0-9]*).*" cleaned;
+  in
+    if match != null
+    then builtins.head match
+    else throw "Cannot detect SDK version from filename: ${filename}. Expected format: MacOSX<version>.sdk.tar.xz";
+
+  # Get target info for an SDK version
+  getTargetInfo = sdkVersion: let
+    # Try exact match first
+    exact = sdkVersionMap.${sdkVersion} or null;
+    # Try major version only
+    majorVersion = builtins.head (lib.splitString "." sdkVersion);
+    major = sdkVersionMap.${majorVersion} or null;
+  in
+    if exact != null
+    then exact
+    else if major != null
+    then major
+    else throw "Unsupported SDK version: ${sdkVersion}. Supported versions: ${builtins.concatStringsSep ", " (builtins.attrNames sdkVersionMap)}";
+
+  # Validate architecture list against SDK-supported architectures
+  validateArchs = {
+    enableArchs,
+    sdkVersion,
+  }: let
+    targetInfo = getTargetInfo sdkVersion;
+    supportedArchs = targetInfo.archs;
+    invalid = lib.filter (a: !(lib.elem a supportedArchs)) enableArchs;
+  in
+    if invalid == []
+    then enableArchs
+    else throw "Unsupported architectures for SDK ${sdkVersion}: ${lib.concatStringsSep ", " invalid}. Supported: ${lib.concatStringsSep ", " supportedArchs}";
+
+  # Map osxcross arch names to Rust target triples
+  archToRustTarget = arch:
+    if arch == "arm64" || arch == "arm64e"
+    then "aarch64-apple-darwin"
+    else if arch == "x86_64" || arch == "x86_64h"
+    then "x86_64-apple-darwin"
+    else if arch == "i386"
+    then "i686-apple-darwin"
+    else throw "No Rust target for architecture: ${arch}";
+
+  # Map Rust target to osxcross arch
+  rustTargetToArch = target:
+    if lib.hasPrefix "aarch64" target
+    then "aarch64"
+    else if lib.hasPrefix "x86_64" target
+    then "x86_64"
+    else if lib.hasPrefix "i686" target || lib.hasPrefix "i386" target
+    then "i386"
+    else throw "Unknown Rust target: ${target}";
+
+  # Compiler wrapper tools (linked to main wrapper)
+  wrapperTools = [
+    "clang"
+    "clang++"
+    "clang++-libc++"
+    "clang++-stdc++"
+    "clang++-gstdc++"
+    "cc"
+    "c++"
+  ];
+
+  # Shortcut prefixes for architecture shortcuts
+  shortcutPrefixes = {
+    "x86_64" = "o64";
+    "i386" = "o32";
+    "arm64" = "oa64";
+    "arm64e" = "oa64e";
+    "aarch64" = "oa64";
+  };
+
+  # OSXCross utility tools that link to the wrapper (get unprefixed AND arch-prefixed symlinks)
+  utilityTools = [
+    "osxcross"
+    "osxcross-conf"
+    "osxcross-cmp"
+    "osxcross-man"
+    "sw_vers"
+    "xcrun"
+    "xcodebuild"
+    "dsymutil"
+  ];
+
+  # Tools that only get arch-prefixed symlinks (no unprefixed version to avoid shadowing system tools)
+  # pkg-config is here to avoid interfering with native Linux builds
+  archOnlyTools = [
+    "pkg-config"
+  ];
+
+  # cctools binaries that exist in cctools-port
+  cctoolsBinaries = [
+    "ar"
+    "as"
+    "bitcode_strip"
+    "check_dylib"
+    "checksyms"
+    "cmpdylib"
+    "codesign_allocate"
+    "ctf_insert"
+    "dyldinfo"
+    "inout"
+    "install_name_tool"
+    "ld"
+    "libtool"
+    "lipo"
+    "machocheck"
+    "makerelocs"
+    "mtoc"
+    "mtor"
+    "nm"
+    "nmedit"
+    "ObjectDump"
+    "otool"
+    "pagestuff"
+    "ranlib"
+    "redo_prebinding"
+    "seg_addr_table"
+    "seg_hack"
+    "segedit"
+    "size"
+    "strings"
+    "strip"
+    "unwinddump"
+    "vtool"
+  ];
+
+  # Generate wrapper symlinks as an attrset: { linkName = targetName; }
+  # This returns pure data, not shell commands
+  getWrapperSymlinks = {
+    supportedArchs,
+    darwinTarget,
+  }: let
+    primaryArch = builtins.head supportedArchs;
+    wrapperBin = "${primaryArch}-apple-${darwinTarget}-wrapper";
+
+    # Arch-prefixed symlinks for wrapper tools (clang, clang++, etc.)
+    archWrapperLinks = lib.listToAttrs (
+      lib.concatMap (
+        arch:
+          map (tool: {
+            name = "${arch}-apple-${darwinTarget}-${tool}";
+            value = wrapperBin;
+          })
+          wrapperTools
+      )
+      supportedArchs
+    );
+
+    # Shortcut symlinks (o64-clang, oa64-clang, etc.)
+    shortcutLinks = lib.listToAttrs (
+      lib.concatMap (
+        arch: let
+          prefix = shortcutPrefixes.${arch} or null;
+        in
+          if prefix != null
+          then
+            map (tool: {
+              name = "${prefix}-${tool}";
+              value = wrapperBin;
+            })
+            wrapperTools
+          else []
+      )
+      supportedArchs
+    );
+
+    # Utility symlinks (unprefixed + arch-prefixed)
+    utilityLinks = lib.listToAttrs (
+      map (tool: {
+        name = tool;
+        value = wrapperBin;
+      })
+      utilityTools
+    );
+
+    # Arch-prefixed symlinks for utility tools
+    archUtilityLinks = lib.listToAttrs (
+      lib.concatMap (
+        arch:
+          map (tool: {
+            name = "${arch}-apple-${darwinTarget}-${tool}";
+            value = wrapperBin;
+          })
+          utilityTools
+      )
+      supportedArchs
+    );
+
+    # Arch-only tools (only arch-prefixed, no unprefixed to avoid shadowing system tools)
+    archOnlyLinks = lib.listToAttrs (
+      lib.concatMap (
+        arch:
+          map (tool: {
+            name = "${arch}-apple-${darwinTarget}-${tool}";
+            value = wrapperBin;
+          })
+          archOnlyTools
+      )
+      supportedArchs
+    );
+  in
+    archWrapperLinks // shortcutLinks // utilityLinks // archUtilityLinks // archOnlyLinks;
+
+  # Generate cctools symlinks as an attrset: { linkName = targetName; }
+  getCctoolsSymlinks = {
+    supportedArchs,
+    darwinTarget,
+    primaryArch,
+  }:
+    lib.listToAttrs (
+      lib.concatMap (
+        arch:
+          if arch == primaryArch
+          then []
+          else
+            map (tool: {
+              name = "${arch}-apple-${darwinTarget}-${tool}";
+              value = "${primaryArch}-apple-${darwinTarget}-${tool}";
+            })
+            cctoolsBinaries
+      )
+      supportedArchs
+    );
+
+  # Convert symlink attrset to shell commands (for backward compatibility during transition)
+  symlinkAttrToShell = binDir: symlinks:
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: target: "ln -sf ${target} ${binDir}/${name}") symlinks
+    );
+
+  # Legacy functions for backward compatibility
+  mkWrapperSymlinks = {
+    supportedArchs,
+    darwinTarget,
+    binDir,
+  }:
+    symlinkAttrToShell binDir (getWrapperSymlinks {inherit supportedArchs darwinTarget;});
+
+  mkCctoolsSymlinks = {
+    supportedArchs,
+    darwinTarget,
+    binDir,
+    primaryArch,
+  }:
+    symlinkAttrToShell binDir (getCctoolsSymlinks {inherit supportedArchs darwinTarget primaryArch;});
+in {
+  inherit
+    sdkVersionMap
+    detectSdkVersion
+    getTargetInfo
+    validateArchs
+    archToRustTarget
+    rustTargetToArch
+    # New pure-data functions
+    wrapperTools
+    shortcutPrefixes
+    utilityTools
+    archOnlyTools
+    cctoolsBinaries
+    getWrapperSymlinks
+    getCctoolsSymlinks
+    symlinkAttrToShell
+    # Legacy shell-generating functions (still available)
+    mkWrapperSymlinks
+    mkCctoolsSymlinks
+    ;
+
+  # Convenience: get supported Rust targets for an SDK
+  getRustTargets = sdkVersion: let
+    info = getTargetInfo sdkVersion;
+    # Deduplicate (arm64 and arm64e map to same Rust target)
+    targets = lib.unique (map archToRustTarget info.archs);
+  in
+    targets;
+
+  # Get the primary architecture (first in list) for an SDK
+  getPrimaryArch = sdkVersion: let
+    info = getTargetInfo sdkVersion;
+  in
+    builtins.head info.archs;
+}

--- a/nix/osxcross.nix
+++ b/nix/osxcross.nix
@@ -222,6 +222,13 @@ in
       # Create tool symlinks
       ${symlinkCommands}
 
+      # Provide an unprefixed `codesign_allocate` (as macOS ships it at
+      # /usr/bin/codesign_allocate). Tools that ad-hoc sign Mach-O binaries —
+      # e.g. sigtool's `codesign` — spawn `codesign_allocate` by bare name via
+      # PATH and fail otherwise unless the caller exports $CODESIGN_ALLOCATE by
+      # hand. All arch variants are the same binary, so alias the primary one.
+      ln -sf "${primaryArch}-apple-${darwinTarget}-codesign_allocate" "$out/bin/codesign_allocate"
+
       # Install CMake toolchain file
       cp "$src/tools/toolchain.cmake" "$out/share/osxcross/"
       ln -sf "$out/share/osxcross/toolchain.cmake" "$out/toolchain.cmake"

--- a/nix/osxcross.nix
+++ b/nix/osxcross.nix
@@ -1,0 +1,314 @@
+# OSXCross - Main package derivation
+# Combines all components into a complete macOS cross-compilation toolchain
+{
+  lib,
+  stdenv,
+  callPackage,
+  makeWrapper,
+  llvmPackages,
+  src, # osxcross source
+  osxcrossLib,
+  sdkPath,
+  sdkVersion ? null,
+  osxVersionMin ? null,
+  enableArchs ? null,
+  enableLTO ? true,
+}: let
+  # Auto-detect SDK version if not provided
+  detectedSdkVersion =
+    if sdkVersion != null
+    then sdkVersion
+    else osxcrossLib.detectSdkVersion (builtins.baseNameOf (toString sdkPath));
+
+  # Get target info from SDK version
+  targetInfo = osxcrossLib.getTargetInfo detectedSdkVersion;
+
+  # Determine architectures to build
+  supportedArchs =
+    if enableArchs != null
+    then
+      osxcrossLib.validateArchs {
+        inherit enableArchs;
+        sdkVersion = detectedSdkVersion;
+      }
+    else targetInfo.archs;
+
+  # Primary architecture (first in list)
+  primaryArch = builtins.head supportedArchs;
+
+  # Darwin target string
+  darwinTarget = targetInfo.target;
+
+  # Minimum OS version
+  effectiveOsxVersionMin =
+    if osxVersionMin != null
+    then osxVersionMin
+    else targetInfo.minVersion;
+
+  # LTO library path
+  libltoPath =
+    if enableLTO
+    then "${llvmPackages.llvm.lib}/lib"
+    else "";
+
+  # Build XAR
+  xar = callPackage ./xar.nix {};
+
+  # Build Apple TAPI (if needed)
+  apple-libtapi =
+    if targetInfo.needsTapi
+    then callPackage ./apple-libtapi.nix {}
+    else null;
+
+  # Build cctools-port
+  cctools-port = callPackage ./cctools-port.nix {
+    inherit xar darwinTarget primaryArch enableLTO;
+    apple-libtapi = apple-libtapi;
+  };
+
+  # Build wrapper
+  wrapper = callPackage ./wrapper.nix {
+    inherit src darwinTarget supportedArchs libltoPath;
+    osxVersionMin = effectiveOsxVersionMin;
+  };
+
+  # Extract SDK
+  sdk = callPackage ./sdk.nix {
+    sdkTarball = sdkPath;
+    sdkVersion = detectedSdkVersion;
+  };
+
+  # Major version for SDK symlink (e.g., "26" from "26.1")
+  majorVersion = builtins.head (lib.splitString "." detectedSdkVersion);
+  needsMajorVersionSymlink = majorVersion != detectedSdkVersion;
+
+  # Get symlink definitions from lib
+  wrapperSymlinks = osxcrossLib.getWrapperSymlinks {inherit supportedArchs darwinTarget;};
+  cctoolsSymlinks = osxcrossLib.getCctoolsSymlinks {inherit supportedArchs darwinTarget primaryArch;};
+  allSymlinks = wrapperSymlinks // cctoolsSymlinks;
+
+  # Generate symlink creation commands
+  symlinkCommands = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (name: target: "ln -sf \"${target}\" \"$out/bin/${name}\"") allSymlinks
+  );
+
+  # SDK symlinks to create
+  sdkSymlinks =
+    [
+      {
+        name = "MacOSX.sdk";
+        target = "${sdk}/MacOSX.sdk";
+      }
+      {
+        name = "MacOSX${detectedSdkVersion}.sdk";
+        target = "${sdk}/MacOSX.sdk";
+      }
+    ]
+    ++ lib.optional needsMajorVersionSymlink {
+      name = "MacOSX${majorVersion}.sdk";
+      target = "${sdk}/MacOSX.sdk";
+    };
+
+  sdkSymlinkCommands = lib.concatMapStringsSep "\n" (s: ''ln -sf "${s.target}" "$out/SDK/${s.name}"'') sdkSymlinks;
+
+  # Script contents defined in Nix
+  osxcrossCmakeScript = ''
+    #!/usr/bin/env bash
+    # OSXCross CMake wrapper
+    OSXCROSS_TARGET_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+    OSXCROSS_HOST="${primaryArch}-apple-${darwinTarget}"
+    OSXCROSS_TARGET="${darwinTarget}"
+    OSXCROSS_SDK="$OSXCROSS_TARGET_DIR/SDK/MacOSX.sdk"
+
+    export OSXCROSS_TARGET_DIR OSXCROSS_HOST OSXCROSS_TARGET OSXCROSS_SDK
+
+    exec cmake \
+      -DCMAKE_TOOLCHAIN_FILE="$OSXCROSS_TARGET_DIR/share/osxcross/toolchain.cmake" \
+      "$@"
+  '';
+
+  archCmakeScript = arch: ''
+    #!/usr/bin/env bash
+    OSXCROSS_HOST="${arch}-apple-${darwinTarget}"
+    export OSXCROSS_HOST
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    exec "$SCRIPT_DIR/osxcross-cmake" "$@"
+  '';
+
+  osxcrossEnvScript = ''
+    #!/usr/bin/env bash
+    # Source this file to set up osxcross environment
+    OSXCROSS_TARGET_DIR="$(cd "$(dirname "''${BASH_SOURCE[0]}")/.." && pwd)"
+    export PATH="$OSXCROSS_TARGET_DIR/bin:$PATH"
+    export OSXCROSS_TARGET_DIR
+    export OSXCROSS_SDK="$OSXCROSS_TARGET_DIR/SDK/MacOSX.sdk"
+    export MACOSX_DEPLOYMENT_TARGET="${effectiveOsxVersionMin}"
+  '';
+
+  configFileContent = ''
+    OSXCROSS_VERSION=1.5
+    SDK_VERSION=${detectedSdkVersion}
+    DARWIN_TARGET=${darwinTarget}
+    OSX_VERSION_MIN=${effectiveOsxVersionMin}
+    SUPPORTED_ARCHS=${lib.concatStringsSep " " supportedArchs}
+    PRIMARY_ARCH=${primaryArch}
+    LTO_ENABLED=${lib.boolToString enableLTO}
+  '';
+
+  # Libraries to copy (as a list for clarity)
+  libSources =
+    [
+      {
+        src = cctools-port;
+        hasLib = true;
+      }
+      {
+        src = xar;
+        hasLib = true;
+      }
+    ]
+    ++ lib.optional (apple-libtapi != null) {
+      src = apple-libtapi;
+      hasLib = true;
+      hasInclude = true;
+    };
+
+  # Generate library copy commands
+  libCopyCommands =
+    lib.concatMapStringsSep "\n" (
+      entry:
+        (lib.optionalString entry.hasLib ''
+          if [ -d "${entry.src}/lib" ]; then
+            cp -r "${entry.src}"/lib/* "$out/lib/" 2>/dev/null || true
+          fi
+        '')
+        + (lib.optionalString (entry.hasInclude or false) ''
+          if [ -d "${entry.src}/include" ]; then
+            mkdir -p "$out/include"
+            cp -r "${entry.src}"/include/* "$out/include/"
+          fi
+        '')
+    )
+    libSources;
+
+  # Generate arch-specific cmake wrapper install commands
+  archCmakeInstallCommands =
+    lib.concatMapStringsSep "\n" (arch: ''
+      cat > "$out/bin/${arch}-apple-${darwinTarget}-cmake" << 'ARCHCMAKE'
+      ${archCmakeScript arch}
+      ARCHCMAKE
+      chmod +x "$out/bin/${arch}-apple-${darwinTarget}-cmake"
+    '')
+    supportedArchs;
+in
+  stdenv.mkDerivation {
+    pname = "osxcross";
+    version = "1.5-sdk${detectedSdkVersion}";
+
+    inherit src;
+
+    nativeBuildInputs = [
+      makeWrapper
+    ];
+
+    dontBuild = true;
+    dontConfigure = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      # Create directory structure
+      mkdir -p "$out"/{bin,lib,SDK,share/osxcross}
+
+      # Copy cctools binaries
+      cp -r "${cctools-port}"/bin/* "$out/bin/"
+
+      # Copy libraries
+      ${libCopyCommands}
+
+      # Copy and wrap the wrapper binary to include unwrapped clang in PATH
+      # We use clang-unwrapped to avoid Nix's cc-wrapper intercepting linker calls
+      for wrapperBin in "${wrapper}"/bin/*-wrapper; do
+        binName=$(basename "$wrapperBin")
+        cp "$wrapperBin" "$out/bin/$binName"
+        wrapProgram "$out/bin/$binName" \
+          --prefix PATH : "${llvmPackages.clang-unwrapped}/bin:$out/bin"
+      done
+
+      # Create SDK symlinks
+      ${sdkSymlinkCommands}
+
+      # Create tool symlinks
+      ${symlinkCommands}
+
+      # Install CMake toolchain file
+      cp "$src/tools/toolchain.cmake" "$out/share/osxcross/"
+      ln -sf "$out/share/osxcross/toolchain.cmake" "$out/toolchain.cmake"
+
+      # Install macports script
+      cp "$src/tools/osxcross-macports" "$out/bin/"
+      chmod +x "$out/bin/osxcross-macports"
+      ln -sf osxcross-macports "$out/bin/osxcross-mp"
+      ln -sf osxcross-macports "$out/bin/omp"
+
+      # Install osxcross-cmake wrapper
+      cat > "$out/bin/osxcross-cmake" << 'CMAKEWRAPPER'
+      ${osxcrossCmakeScript}
+      CMAKEWRAPPER
+      chmod +x "$out/bin/osxcross-cmake"
+
+      # Install architecture-specific cmake wrappers
+      ${archCmakeInstallCommands}
+
+      # Install environment setup script
+      cat > "$out/bin/osxcross-env" << 'ENVSCRIPT'
+      ${osxcrossEnvScript}
+      ENVSCRIPT
+      chmod +x "$out/bin/osxcross-env"
+
+      # Store configuration for reference
+      cat > "$out/share/osxcross/config" << 'CONFIG'
+      ${configFileContent}
+      CONFIG
+
+      runHook postInstall
+    '';
+
+    # Expose attributes for downstream use
+    passthru = {
+      inherit
+        detectedSdkVersion
+        darwinTarget
+        supportedArchs
+        primaryArch
+        effectiveOsxVersionMin
+        sdk
+        cctools-port
+        wrapper
+        xar
+        apple-libtapi
+        ;
+
+      # Helper to get compiler for a specific arch
+      getCompiler = arch: "${placeholder "out"}/bin/${arch}-apple-${darwinTarget}-clang";
+      getCompilerCxx = arch: "${placeholder "out"}/bin/${arch}-apple-${darwinTarget}-clang++";
+      getAr = arch: "${placeholder "out"}/bin/${arch}-apple-${darwinTarget}-ar";
+      getLd = arch: "${placeholder "out"}/bin/${arch}-apple-${darwinTarget}-ld";
+    };
+
+    meta = with lib; {
+      description = "macOS cross-compilation toolchain for Linux";
+      longDescription = ''
+        OSXCross is a toolchain that allows you to compile macOS binaries
+        on Linux. This package includes:
+        - Apple cctools (ar, as, ld, lipo, nm, otool, etc.)
+        - ld64 linker
+        - Compiler wrappers for clang
+        - macOS SDK ${detectedSdkVersion}
+      '';
+      homepage = "https://github.com/tpoechtrager/osxcross";
+      license = licenses.gpl2Plus;
+      platforms = platforms.linux;
+      maintainers = [];
+    };
+  }

--- a/nix/osxcross.nix
+++ b/nix/osxcross.nix
@@ -8,17 +8,26 @@
   llvmPackages,
   src, # osxcross source
   osxcrossLib,
-  sdkPath,
+  macosSdk,
   sdkVersion ? null,
   osxVersionMin ? null,
   enableArchs ? null,
   enableLTO ? true,
 }: let
+  macosSdkVersion =
+    macosSdk.sdkVersion or (throw "osxcross: macosSdk.sdkVersion is required");
+
   # Auto-detect SDK version if not provided
   detectedSdkVersion =
     if sdkVersion != null
-    then sdkVersion
-    else osxcrossLib.detectSdkVersion (builtins.baseNameOf (toString sdkPath));
+    then
+      if sdkVersion == macosSdkVersion
+      then sdkVersion
+      else throw "osxcross: sdkVersion (${sdkVersion}) does not match macosSdk.sdkVersion (${macosSdkVersion})"
+    else macosSdkVersion;
+
+  sdk = macosSdk.sdk or (throw "osxcross: macosSdk.sdk is required");
+  sdkRoot = macosSdk.sdkRoot or "${sdk}/MacOSX${detectedSdkVersion}.sdk";
 
   # Get target info from SDK version
   targetInfo = osxcrossLib.getTargetInfo detectedSdkVersion;
@@ -72,16 +81,6 @@
     osxVersionMin = effectiveOsxVersionMin;
   };
 
-  # Extract SDK
-  sdk = callPackage ./sdk.nix {
-    sdkTarball = sdkPath;
-    sdkVersion = detectedSdkVersion;
-  };
-
-  # Major version for SDK symlink (e.g., "26" from "26.1")
-  majorVersion = builtins.head (lib.splitString "." detectedSdkVersion);
-  needsMajorVersionSymlink = majorVersion != detectedSdkVersion;
-
   # Get symlink definitions from lib
   wrapperSymlinks = osxcrossLib.getWrapperSymlinks {inherit supportedArchs darwinTarget;};
   cctoolsSymlinks = osxcrossLib.getCctoolsSymlinks {inherit supportedArchs darwinTarget primaryArch;};
@@ -92,25 +91,6 @@
     lib.mapAttrsToList (name: target: "ln -sf \"${target}\" \"$out/bin/${name}\"") allSymlinks
   );
 
-  # SDK symlinks to create
-  sdkSymlinks =
-    [
-      {
-        name = "MacOSX.sdk";
-        target = "${sdk}/MacOSX.sdk";
-      }
-      {
-        name = "MacOSX${detectedSdkVersion}.sdk";
-        target = "${sdk}/MacOSX.sdk";
-      }
-    ]
-    ++ lib.optional needsMajorVersionSymlink {
-      name = "MacOSX${majorVersion}.sdk";
-      target = "${sdk}/MacOSX.sdk";
-    };
-
-  sdkSymlinkCommands = lib.concatMapStringsSep "\n" (s: ''ln -sf "${s.target}" "$out/SDK/${s.name}"'') sdkSymlinks;
-
   # Script contents defined in Nix
   osxcrossCmakeScript = ''
     #!/usr/bin/env bash
@@ -118,9 +98,10 @@
     OSXCROSS_TARGET_DIR="$(cd "$(dirname "$0")/.." && pwd)"
     OSXCROSS_HOST="${primaryArch}-apple-${darwinTarget}"
     OSXCROSS_TARGET="${darwinTarget}"
-    OSXCROSS_SDK="$OSXCROSS_TARGET_DIR/SDK/MacOSX.sdk"
+    OSXCROSS_SDK="${sdkRoot}"
+    OSXCROSS_SDKROOT="${sdkRoot}"
 
-    export OSXCROSS_TARGET_DIR OSXCROSS_HOST OSXCROSS_TARGET OSXCROSS_SDK
+    export OSXCROSS_TARGET_DIR OSXCROSS_HOST OSXCROSS_TARGET OSXCROSS_SDK OSXCROSS_SDKROOT
 
     exec cmake \
       -DCMAKE_TOOLCHAIN_FILE="$OSXCROSS_TARGET_DIR/share/osxcross/toolchain.cmake" \
@@ -141,7 +122,8 @@
     OSXCROSS_TARGET_DIR="$(cd "$(dirname "''${BASH_SOURCE[0]}")/.." && pwd)"
     export PATH="$OSXCROSS_TARGET_DIR/bin:$PATH"
     export OSXCROSS_TARGET_DIR
-    export OSXCROSS_SDK="$OSXCROSS_TARGET_DIR/SDK/MacOSX.sdk"
+    export OSXCROSS_SDK="${sdkRoot}"
+    export OSXCROSS_SDKROOT="${sdkRoot}"
     export MACOSX_DEPLOYMENT_TARGET="${effectiveOsxVersionMin}"
   '';
 
@@ -218,7 +200,7 @@ in
       runHook preInstall
 
       # Create directory structure
-      mkdir -p "$out"/{bin,lib,SDK,share/osxcross}
+      mkdir -p "$out"/{bin,lib,share/osxcross}
 
       # Copy cctools binaries
       cp -r "${cctools-port}"/bin/* "$out/bin/"
@@ -232,11 +214,10 @@ in
         binName=$(basename "$wrapperBin")
         cp "$wrapperBin" "$out/bin/$binName"
         wrapProgram "$out/bin/$binName" \
+          --set-default OSXCROSS_SDK "${sdkRoot}" \
+          --set-default OSXCROSS_SDKROOT "${sdkRoot}" \
           --prefix PATH : "${llvmPackages.clang-unwrapped}/bin:$out/bin"
       done
-
-      # Create SDK symlinks
-      ${sdkSymlinkCommands}
 
       # Create tool symlinks
       ${symlinkCommands}
@@ -283,6 +264,8 @@ in
         primaryArch
         effectiveOsxVersionMin
         sdk
+        sdkRoot
+        macosSdk
         cctools-port
         wrapper
         xar

--- a/nix/realize-macos-sdk.nix
+++ b/nix/realize-macos-sdk.nix
@@ -1,0 +1,149 @@
+{
+  pkgs,
+  osxcross,
+}:
+pkgs.writeShellApplication {
+  name = "realize-macos-sdk";
+  runtimeInputs = [
+    pkgs.coreutils
+    pkgs.nix
+  ];
+  text = ''
+    set -euo pipefail
+
+    usage() {
+      cat <<'USAGE'
+    Usage:
+      realize-macos-sdk [--env] /path/to/MacOSX26.1.sdk.tar.xz 26.1
+
+    Realize a local macOS SDK archive into a stable Nix store output.
+
+    Options:
+      --env      Print shell assignments for scripting
+      -h, --help Show this help
+
+    Output includes:
+      Store path
+      SDK root
+      SDK version
+      Recursive hash
+    USAGE
+    }
+
+    emit_env() {
+      printf 'STORE_PATH=%q\n' "$1"
+      printf 'SDK_ROOT=%q\n' "$2"
+      printf 'SDK_VERSION=%q\n' "$3"
+      printf 'RECURSIVE_HASH=%q\n' "$4"
+    }
+
+    mode="human"
+    case "''${1:-}" in
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      --env)
+        mode="env"
+        shift
+        ;;
+    esac
+
+    if [ "$#" -ne 2 ]; then
+      usage >&2
+      exit 64
+    fi
+
+    archive="$1"
+    sdk_version="$2"
+
+    if [ "''${archive#/}" = "$archive" ]; then
+      archive="$(realpath "$archive")"
+    fi
+
+    if [ ! -f "$archive" ]; then
+      echo "error: SDK archive does not exist: $archive" >&2
+      exit 66
+    fi
+
+    if [ -z "$sdk_version" ]; then
+      echo "error: SDK version must not be empty" >&2
+      exit 64
+    fi
+
+    sdk_expr="$(cat <<'NIX_EXPR'
+    let
+      osxcrossFlake = builtins.getFlake (builtins.getEnv "OSXCROSS_FLAKE_PATH");
+      system = builtins.currentSystem;
+      sdkArchivePath = builtins.getEnv "OSXCROSS_SDK_ARCHIVE";
+      sdkVersion = builtins.getEnv "OSXCROSS_SDK_VERSION";
+      outputHashValue = builtins.getEnv "OSXCROSS_SDK_OUTPUT_HASH";
+      sdkArgs =
+        {
+          sdkArchive = /. + sdkArchivePath;
+          inherit sdkVersion;
+        }
+        // (
+          if outputHashValue == ""
+          then {}
+          else {outputHash = outputHashValue;}
+        );
+      osxcrossLib = builtins.getAttr system osxcrossFlake.lib;
+      macosSdk =
+        if osxcrossLib ? mkMacosSdk
+        then osxcrossLib.mkMacosSdk sdkArgs
+        else throw "realize-macos-sdk requires an osxcross input that exposes lib.<system>.mkMacosSdk";
+    in
+      macosSdk.sdk
+    NIX_EXPR
+    )"
+
+    nix_cmd=(nix --extra-experimental-features "nix-command flakes")
+
+    export OSXCROSS_FLAKE_PATH="${osxcross.outPath}"
+    export OSXCROSS_SDK_ARCHIVE="$archive"
+    export OSXCROSS_SDK_VERSION="$sdk_version"
+    export OSXCROSS_SDK_OUTPUT_HASH=""
+
+    echo "Building bootstrap SDK from local archive..." >&2
+    bootstrap_out="$(
+      "''${nix_cmd[@]}" build --impure --no-link --print-out-paths --expr "$sdk_expr"
+    )"
+
+    recursive_hash="$("''${nix_cmd[@]}" hash path "$bootstrap_out")"
+
+    export OSXCROSS_SDK_OUTPUT_HASH="$recursive_hash"
+    echo "Rebuilding fixed-output SDK with recursive hash..." >&2
+    final_out="$(
+      "''${nix_cmd[@]}" build --impure --no-link --print-out-paths --expr "$sdk_expr"
+    )"
+
+    sdk_root="$final_out/MacOSX$sdk_version.sdk"
+
+    if [ ! -d "$sdk_root" ]; then
+      echo "error: expected SDK root was not produced: $sdk_root" >&2
+      exit 70
+    fi
+
+    if [ "$mode" = "env" ]; then
+      emit_env "$final_out" "$sdk_root" "$sdk_version" "$recursive_hash"
+      exit 0
+    fi
+
+    cat <<EOF
+    macOS SDK realized.
+
+    Store path:
+    $final_out
+
+    SDK root:
+    $sdk_root
+
+    SDK version:
+    $sdk_version
+
+    Recursive hash:
+    $recursive_hash
+    EOF
+  '';
+}

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -1,0 +1,224 @@
+# OSXCross Rust cross-compilation support
+# Helpers for integrating osxcross with rust-overlay and crane
+{
+  lib,
+  pkgs,
+  osxcross, # The built osxcross toolchain
+}: let
+  inherit (osxcross) darwinTarget supportedArchs;
+
+  # Map osxcross arch to Rust target triple
+  archToRustTarget = arch:
+    if arch == "arm64" || arch == "aarch64" || arch == "arm64e"
+    then "aarch64-apple-darwin"
+    else if arch == "x86_64" || arch == "x86_64h"
+    then "x86_64-apple-darwin"
+    else if arch == "i386"
+    then "i686-apple-darwin"
+    else throw "No Rust target for architecture: ${arch}";
+
+  # Map Rust target to osxcross arch prefix (used in binary names)
+  rustTargetToArch = target:
+    if lib.hasPrefix "aarch64" target
+    then "arm64" # osxcross uses arm64, not aarch64
+    else if lib.hasPrefix "x86_64" target
+    then "x86_64"
+    else if lib.hasPrefix "i686" target || lib.hasPrefix "i386" target
+    then "i386"
+    else throw "Unknown Rust target: ${target}";
+
+  # Get unique Rust targets supported by this osxcross build
+  rustTargets = lib.unique (map archToRustTarget supportedArchs);
+
+  # Convert Rust target triple to environment variable name format
+  # e.g., "aarch64-apple-darwin" -> "AARCH64_APPLE_DARWIN"
+  targetToEnvName = target:
+    lib.toUpper (lib.replaceStrings ["-"] ["_"] target);
+
+  # Generate Cargo environment variables for a specific Rust target
+  cargoEnvFor = rustTarget: let
+    arch = rustTargetToArch rustTarget;
+    envName = targetToEnvName rustTarget;
+    # cc-rs uses lowercase with underscores: aarch64_apple_darwin
+    ccEnvName = lib.replaceStrings ["-"] ["_"] rustTarget;
+  in {
+    # Cargo linker/ar settings
+    "CARGO_TARGET_${envName}_LINKER" = "${osxcross}/bin/${arch}-apple-${darwinTarget}-clang";
+    "CARGO_TARGET_${envName}_AR" = "${osxcross}/bin/${arch}-apple-${darwinTarget}-ar";
+
+    # cc-rs crate environment variables (uses underscores: CC_aarch64_apple_darwin)
+    "CC_${ccEnvName}" = "${osxcross}/bin/${arch}-apple-${darwinTarget}-clang";
+    "CXX_${ccEnvName}" = "${osxcross}/bin/${arch}-apple-${darwinTarget}-clang++";
+    "AR_${ccEnvName}" = "${osxcross}/bin/${arch}-apple-${darwinTarget}-ar";
+  };
+
+  # Generate environment variables for all supported targets
+  cargoEnvAll = lib.foldl' (acc: target: acc // (cargoEnvFor target)) {} rustTargets;
+
+  # Common environment variables
+  commonEnv = {
+    OSXCROSS_TARGET_DIR = "${osxcross}";
+    OSXCROSS_SDK = "${osxcross}/SDK/MacOSX.sdk";
+    MACOSX_DEPLOYMENT_TARGET = osxcross.effectiveOsxVersionMin;
+  };
+
+  # Generate .cargo/config.toml content for cross-compilation
+  mkCargoConfig = {deploymentTarget ? osxcross.effectiveOsxVersionMin}: let
+    mkTargetSection = rustTarget: let
+      arch = rustTargetToArch rustTarget;
+    in ''
+      [target.${rustTarget}]
+      linker = "${osxcross}/bin/${arch}-apple-${darwinTarget}-clang"
+      ar = "${osxcross}/bin/${arch}-apple-${darwinTarget}-ar"
+      rustflags = ["-C", "link-arg=-mmacosx-version-min=${deploymentTarget}"]
+    '';
+  in
+    lib.concatMapStringsSep "\n" mkTargetSection rustTargets;
+
+  # Write .cargo/config.toml to a file
+  writeCargoConfig = {deploymentTarget ? osxcross.effectiveOsxVersionMin}:
+    pkgs.writeText "cargo-config.toml" (mkCargoConfig {inherit deploymentTarget;});
+
+  # Wrap a crane library for cross-compilation to a specific target
+  mkCrossBuilder = {
+    craneLib,
+    target,
+  }: let
+    cargoEnv = cargoEnvFor target;
+  in {
+    # Build package with cross-compilation
+    buildPackage = args:
+      craneLib.buildPackage (args
+        // cargoEnv
+        // {
+          cargoExtraArgs = (args.cargoExtraArgs or "") + " --target ${target}";
+          nativeBuildInputs = (args.nativeBuildInputs or []) ++ [osxcross];
+          # Ensure linker can find osxcross libs
+          LD_LIBRARY_PATH = "${osxcross}/lib";
+        });
+
+    # Build dependencies only
+    buildDepsOnly = args:
+      craneLib.buildDepsOnly (args
+        // cargoEnv
+        // {
+          cargoExtraArgs = (args.cargoExtraArgs or "") + " --target ${target}";
+          nativeBuildInputs = (args.nativeBuildInputs or []) ++ [osxcross];
+          LD_LIBRARY_PATH = "${osxcross}/lib";
+        });
+
+    # Clippy check
+    cargoClippy = args:
+      craneLib.cargoClippy (args
+        // cargoEnv
+        // {
+          cargoClippyExtraArgs = (args.cargoClippyExtraArgs or "") + " --target ${target}";
+          nativeBuildInputs = (args.nativeBuildInputs or []) ++ [osxcross];
+        });
+
+    # Format check (doesn't need cross-compilation)
+    cargoFmt = args: craneLib.cargoFmt args;
+  };
+
+  # Create universal (fat) binary from arm64 + x86_64 builds
+  mkUniversalBinary = {
+    name,
+    arm64Drv,
+    x86_64Drv,
+    binaries ? [name],
+    outputPath ? "bin",
+  }:
+    pkgs.runCommand "${name}-universal" {
+      nativeBuildInputs = [osxcross];
+    } ''
+      mkdir -p $out/${outputPath}
+
+      ${lib.concatMapStringsSep "\n" (bin: ''
+          echo "Creating universal binary: ${bin}"
+          ${osxcross}/bin/lipo -create \
+            -output $out/${outputPath}/${bin} \
+            ${arm64Drv}/${outputPath}/${bin} \
+            ${x86_64Drv}/${outputPath}/${bin}
+
+          echo "Verifying universal binary:"
+          file $out/${outputPath}/${bin}
+        '')
+        binaries}
+    '';
+
+  # Create universal binary from library builds
+  mkUniversalLibrary = {
+    name,
+    arm64Drv,
+    x86_64Drv,
+    libraries ? ["lib${name}.a" "lib${name}.dylib"],
+    outputPath ? "lib",
+  }:
+    pkgs.runCommand "${name}-universal-lib" {
+      nativeBuildInputs = [osxcross];
+    } ''
+      mkdir -p $out/${outputPath}
+
+      ${lib.concatMapStringsSep "\n" (libFile: ''
+          arm64Path="${arm64Drv}/${outputPath}/${libFile}"
+          x86Path="${x86_64Drv}/${outputPath}/${libFile}"
+
+          if [ -f "$arm64Path" ] && [ -f "$x86Path" ]; then
+            echo "Creating universal library: ${libFile}"
+            ${osxcross}/bin/lipo -create \
+              -output $out/${outputPath}/${libFile} \
+              "$arm64Path" \
+              "$x86Path"
+          elif [ -f "$arm64Path" ]; then
+            echo "Only arm64 available for ${libFile}, copying..."
+            cp "$arm64Path" $out/${outputPath}/${libFile}
+          elif [ -f "$x86Path" ]; then
+            echo "Only x86_64 available for ${libFile}, copying..."
+            cp "$x86Path" $out/${outputPath}/${libFile}
+          else
+            echo "Warning: ${libFile} not found in either build"
+          fi
+        '')
+        libraries}
+    '';
+
+  # Development shell setup for Rust cross-compilation
+  mkDevShellHook = {deploymentTarget ? osxcross.effectiveOsxVersionMin}: let
+    envVars = commonEnv // cargoEnvAll;
+    exports = lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: value: "export ${name}=\"${value}\"") envVars
+    );
+  in ''
+    # OSXCross Rust cross-compilation environment
+    export PATH="${osxcross}/bin:$PATH"
+    ${exports}
+
+    # Create .cargo/config.toml if it doesn't exist
+    if [ ! -f .cargo/config.toml ]; then
+      mkdir -p .cargo
+      cat > .cargo/config.toml << 'CARGOCONFIG'
+    ${mkCargoConfig {inherit deploymentTarget;}}
+    CARGOCONFIG
+      echo "Created .cargo/config.toml for cross-compilation"
+    fi
+
+    echo "OSXCross Rust environment configured"
+    echo "  Targets: ${lib.concatStringsSep ", " rustTargets}"
+    echo "  SDK: macOS ${osxcross.detectedSdkVersion}"
+    echo "  Min deployment: ${deploymentTarget}"
+  '';
+in {
+  # Expose all helpers
+  inherit
+    rustTargets
+    cargoEnvFor
+    cargoEnvAll
+    commonEnv
+    mkCargoConfig
+    writeCargoConfig
+    mkCrossBuilder
+    mkUniversalBinary
+    mkUniversalLibrary
+    mkDevShellHook
+    ;
+}

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -6,6 +6,7 @@
   osxcross, # The built osxcross toolchain
 }: let
   inherit (osxcross) darwinTarget supportedArchs;
+  sdkRoot = osxcross.sdkRoot or "${osxcross.sdk}/MacOSX${osxcross.detectedSdkVersion}.sdk";
 
   # Map osxcross arch to Rust target triple
   archToRustTarget = arch:
@@ -58,7 +59,8 @@
   # Common environment variables
   commonEnv = {
     OSXCROSS_TARGET_DIR = "${osxcross}";
-    OSXCROSS_SDK = "${osxcross}/SDK/MacOSX.sdk";
+    OSXCROSS_SDK = sdkRoot;
+    OSXCROSS_SDKROOT = sdkRoot;
     MACOSX_DEPLOYMENT_TARGET = osxcross.effectiveOsxVersionMin;
   };
 

--- a/nix/sdk.nix
+++ b/nix/sdk.nix
@@ -12,6 +12,7 @@
   pbzx ? null, # Optional: for .xip extraction
   sdkTarball,
   sdkVersion,
+  outputHash ? null,
 }: let
   # Determine archive type and extraction command based on file extension
   tarballName = builtins.baseNameOf (toString sdkTarball);
@@ -51,7 +52,7 @@
     "Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk"
   ];
 in
-  stdenv.mkDerivation {
+  stdenv.mkDerivation ({
     pname = "macosx-sdk";
     version = sdkVersion;
 
@@ -109,7 +110,7 @@ in
       fi
 
       echo "Found SDK at: $sdkSource"
-      sdkName=$(basename "$sdkSource")
+      canonicalSdkName="${expectedSdkName}"
 
       # Validate SDK version from SDKSettings.json
       settingsFile="$sdkSource/SDKSettings.json"
@@ -123,7 +124,7 @@ in
           echo "  Actual (from SDKSettings.json): $actualVersion"
           echo ""
           echo "If the tarball was renamed, pass the correct version:"
-          echo "  mkOsxcross { sdkPath = ...; sdkVersion = \"$actualVersion\"; }"
+          echo "  mkMacosSdk { sdkArchive = ...; sdkVersion = \"$actualVersion\"; }"
           exit 1
         fi
         echo "SDK version verified: $actualVersion"
@@ -132,23 +133,18 @@ in
         actualVersion="${sdkVersion}"
       fi
 
-      # Move SDK to output
-      mv "$sdkSource" "$out/$sdkName"
+      # Move SDK to its canonical, versioned location.
+      mv "$sdkSource" "$out/$canonicalSdkName"
 
       # Write the verified version to output for reference
       echo "$actualVersion" > "$out/sdk-version"
 
       # Apply SDK fixups (from build.sh)
       # Remove problematic libcxx.imp file that can cause build issues
-      rm -f "$out/$sdkName/usr/include/c++/v1/libcxx.imp" || true
+      rm -f "$out/$canonicalSdkName/usr/include/c++/v1/libcxx.imp" || true
 
       # Fix permissions
-      chmod -R u+w "$out/$sdkName" || true
-
-      # Create version symlinks for convenience
-      ln -sf "$sdkName" "$out/${expectedSdkName}" || true
-      ln -sf "$sdkName" "$out/MacOSX.sdk"
-      ln -sf "$sdkName" "$out/default"
+      chmod -R u+w "$out/$canonicalSdkName" || true
 
       runHook postInstall
     '';
@@ -163,3 +159,8 @@ in
       maintainers = [];
     };
   }
+  // lib.optionalAttrs (outputHash != null) {
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    inherit outputHash;
+  })

--- a/nix/sdk.nix
+++ b/nix/sdk.nix
@@ -1,0 +1,137 @@
+# macOS SDK extraction
+# Extracts and prepares the macOS SDK for use with osxcross
+{
+  lib,
+  stdenv,
+  gnutar,
+  xz,
+  gzip,
+  bzip2,
+  cpio,
+  pbzx ? null, # Optional: for .xip extraction
+  sdkTarball,
+  sdkVersion,
+}: let
+  # Determine archive type and extraction command based on file extension
+  tarballName = builtins.baseNameOf (toString sdkTarball);
+
+  archiveInfo =
+    if lib.hasSuffix ".tar.xz" tarballName
+    then {
+      type = "tar.xz";
+      extractCmd = "${xz}/bin/xz -dc ${sdkTarball} | ${gnutar}/bin/tar xf -";
+    }
+    else if lib.hasSuffix ".tar.gz" tarballName || lib.hasSuffix ".tgz" tarballName
+    then {
+      type = "tar.gz";
+      extractCmd = "${gzip}/bin/gzip -dc ${sdkTarball} | ${gnutar}/bin/tar xf -";
+    }
+    else if lib.hasSuffix ".tar.bz2" tarballName || lib.hasSuffix ".tbz2" tarballName
+    then {
+      type = "tar.bz2";
+      extractCmd = "${bzip2}/bin/bzip2 -dc ${sdkTarball} | ${gnutar}/bin/tar xf -";
+    }
+    else if lib.hasSuffix ".tar" tarballName
+    then {
+      type = "tar";
+      extractCmd = "${gnutar}/bin/tar xf ${sdkTarball}";
+    }
+    else throw "Unknown archive format for SDK tarball: ${tarballName}. Supported formats: .tar.xz, .tar.gz, .tgz, .tar.bz2, .tbz2, .tar";
+
+  # SDK directory name based on version (what we expect to find after extraction)
+  expectedSdkName = "MacOSX${sdkVersion}.sdk";
+
+  # Possible locations where the SDK might be found after extraction
+  # Listed in order of preference
+  sdkSearchPaths = [
+    "MacOSX*.sdk"
+    "SDKs/MacOSX*.sdk"
+    "Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX*.sdk"
+    "Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk"
+  ];
+in
+  stdenv.mkDerivation {
+    pname = "macosx-sdk";
+    version = sdkVersion;
+
+    src = sdkTarball;
+
+    nativeBuildInputs =
+      [
+        gnutar
+        xz
+        gzip
+        bzip2
+        cpio
+      ]
+      ++ lib.optional (pbzx != null) pbzx;
+
+    # Don't try to unpack automatically
+    dontUnpack = true;
+
+    buildPhase = ''
+      runHook preBuild
+      echo "Extracting ${archiveInfo.type} archive..."
+      ${archiveInfo.extractCmd}
+      runHook postBuild
+    '';
+
+    installPhase = let
+      # Generate the search logic for SDK directory
+      searchScript = lib.concatMapStringsSep "\n" (pattern: ''
+        if [ -z "$sdkSource" ]; then
+          for dir in ${pattern}; do
+            if [ -d "$dir" ]; then
+              sdkSource="$dir"
+              break
+            fi
+          done
+        fi
+      '') sdkSearchPaths;
+    in ''
+      runHook preInstall
+
+      mkdir -p $out
+
+      # Find the SDK directory
+      sdkSource=""
+      ${searchScript}
+
+      if [ -z "$sdkSource" ]; then
+        echo "ERROR: Cannot find SDK directory"
+        echo "Contents of extraction:"
+        find . -maxdepth 3 -type d
+        exit 1
+      fi
+
+      echo "Found SDK at: $sdkSource"
+      sdkName=$(basename "$sdkSource")
+
+      # Move SDK to output
+      mv "$sdkSource" "$out/$sdkName"
+
+      # Apply SDK fixups (from build.sh)
+      # Remove problematic libcxx.imp file that can cause build issues
+      rm -f "$out/$sdkName/usr/include/c++/v1/libcxx.imp" || true
+
+      # Fix permissions
+      chmod -R u+w "$out/$sdkName" || true
+
+      # Create version symlinks for convenience
+      ln -sf "$sdkName" "$out/${expectedSdkName}" || true
+      ln -sf "$sdkName" "$out/MacOSX.sdk"
+      ln -sf "$sdkName" "$out/default"
+
+      runHook postInstall
+    '';
+
+  # Don't run fixup - SDK should remain as-is
+  dontFixup = true;
+
+  meta = with lib; {
+    description = "macOS ${sdkVersion} SDK";
+    license = licenses.unfree; # Apple SDK license
+    platforms = platforms.all;
+    maintainers = [];
+  };
+}

--- a/nix/sdk.nix
+++ b/nix/sdk.nix
@@ -8,6 +8,7 @@
   gzip,
   bzip2,
   cpio,
+  jq,
   pbzx ? null, # Optional: for .xip extraction
   sdkTarball,
   sdkVersion,
@@ -63,6 +64,7 @@ in
         gzip
         bzip2
         cpio
+        jq
       ]
       ++ lib.optional (pbzx != null) pbzx;
 
@@ -78,16 +80,18 @@ in
 
     installPhase = let
       # Generate the search logic for SDK directory
-      searchScript = lib.concatMapStringsSep "\n" (pattern: ''
-        if [ -z "$sdkSource" ]; then
-          for dir in ${pattern}; do
-            if [ -d "$dir" ]; then
-              sdkSource="$dir"
-              break
-            fi
-          done
-        fi
-      '') sdkSearchPaths;
+      searchScript =
+        lib.concatMapStringsSep "\n" (pattern: ''
+          if [ -z "$sdkSource" ]; then
+            for dir in ${pattern}; do
+              if [ -d "$dir" ]; then
+                sdkSource="$dir"
+                break
+              fi
+            done
+          fi
+        '')
+        sdkSearchPaths;
     in ''
       runHook preInstall
 
@@ -107,8 +111,32 @@ in
       echo "Found SDK at: $sdkSource"
       sdkName=$(basename "$sdkSource")
 
+      # Validate SDK version from SDKSettings.json
+      settingsFile="$sdkSource/SDKSettings.json"
+      if [ -f "$settingsFile" ]; then
+        actualVersion=$(jq -r '.Version' "$settingsFile")
+        expectedVersion="${sdkVersion}"
+
+        if [ "$actualVersion" != "$expectedVersion" ]; then
+          echo "ERROR: SDK version mismatch!"
+          echo "  Expected (from filename): $expectedVersion"
+          echo "  Actual (from SDKSettings.json): $actualVersion"
+          echo ""
+          echo "If the tarball was renamed, pass the correct version:"
+          echo "  mkOsxcross { sdkPath = ...; sdkVersion = \"$actualVersion\"; }"
+          exit 1
+        fi
+        echo "SDK version verified: $actualVersion"
+      else
+        echo "WARNING: SDKSettings.json not found, cannot verify SDK version"
+        actualVersion="${sdkVersion}"
+      fi
+
       # Move SDK to output
       mv "$sdkSource" "$out/$sdkName"
+
+      # Write the verified version to output for reference
+      echo "$actualVersion" > "$out/sdk-version"
 
       # Apply SDK fixups (from build.sh)
       # Remove problematic libcxx.imp file that can cause build issues
@@ -125,13 +153,13 @@ in
       runHook postInstall
     '';
 
-  # Don't run fixup - SDK should remain as-is
-  dontFixup = true;
+    # Don't run fixup - SDK should remain as-is
+    dontFixup = true;
 
-  meta = with lib; {
-    description = "macOS ${sdkVersion} SDK";
-    license = licenses.unfree; # Apple SDK license
-    platforms = platforms.all;
-    maintainers = [];
-  };
-}
+    meta = with lib; {
+      description = "macOS ${sdkVersion} SDK";
+      license = licenses.unfree; # Apple SDK license
+      platforms = platforms.all;
+      maintainers = [];
+    };
+  }

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -1,0 +1,68 @@
+# OSXCross compiler wrapper
+# C++ program that wraps clang/gcc for cross-compilation
+{
+  lib,
+  stdenv,
+  llvmPackages,
+  src, # osxcross source
+  osxcrossVersion ? "1.5",
+  darwinTarget,
+  osxVersionMin,
+  linkerVersion ? "951.9",
+  supportedArchs,
+  libltoPath ? "",
+}: let
+  primaryArch = builtins.head supportedArchs;
+  wrapperBinaryName = "${primaryArch}-apple-${darwinTarget}-wrapper";
+in
+  stdenv.mkDerivation {
+    pname = "osxcross-wrapper";
+    version = osxcrossVersion;
+
+    inherit src;
+    sourceRoot = "source/wrapper";
+
+    unpackPhase = ''
+      mkdir source
+      cp -r "$src"/* source/
+      chmod -R u+w source
+    '';
+
+    nativeBuildInputs = [
+      llvmPackages.clang
+    ];
+
+    # Build-time constants compiled into the wrapper
+    makeFlags = [
+      "CXX=${llvmPackages.clang}/bin/clang++"
+      "VERSION=${osxcrossVersion}"
+      "TARGET=${darwinTarget}"
+      "OSX_VERSION_MIN=${osxVersionMin}"
+      "LINKER_VERSION=${linkerVersion}"
+      "BUILD_DIR="
+      "LIBLTO_PATH=${libltoPath}"
+      "PLATFORM=Linux"
+    ];
+
+    # SUPPORTED_ARCHS contains spaces, so pass via environment
+    env = {
+      OPTIMIZE = "2";
+      LTO = "0"; # Don't use LTO for wrapper itself
+      SUPPORTED_ARCHS = lib.concatStringsSep " " supportedArchs;
+    };
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/bin"
+      cp wrapper "$out/bin/${wrapperBinaryName}"
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "OSXCross compiler wrapper";
+      homepage = "https://github.com/tpoechtrager/osxcross";
+      license = licenses.gpl2Plus;
+      platforms = platforms.unix;
+      maintainers = [];
+    };
+  }

--- a/nix/xar.nix
+++ b/nix/xar.nix
@@ -1,0 +1,86 @@
+# XAR archive tool (osxcross fork)
+# Required for extracting macOS SDK packages
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoconf,
+  automake,
+  libtool,
+  pkg-config,
+  openssl,
+  libxml2,
+  zlib,
+  bzip2,
+  xz,
+}:
+stdenv.mkDerivation rec {
+  pname = "xar";
+  version = "1.6.1-osxcross";
+
+  src = fetchFromGitHub {
+    owner = "tpoechtrager";
+    repo = "xar";
+    rev = "xar-1.6.1";
+    hash = "sha256-vuHuRZhigVYWnpuCmk0ShlWwEEvnGMnQDoMG6/d8UAo=";
+  };
+
+  sourceRoot = "${src.name}/xar";
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    libxml2
+    zlib
+    bzip2
+    xz
+  ];
+
+  # Patch configure.ac to work with OpenSSL 3.0+
+  # OpenSSL_add_all_ciphers was removed in OpenSSL 3.0
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace-fail 'OpenSSL_add_all_ciphers' 'EVP_aes_256_cbc'
+  '';
+
+  preConfigure = ''
+    ./autogen.sh --noconfigure
+    export LDFLAGS="-L${openssl.out}/lib"
+    export CPPFLAGS="-I${openssl.dev}/include"
+    export LIBS="-lcrypto -lssl"
+  '';
+
+  configureFlags = [
+    "--with-lzma=${xz.dev}"
+    "--with-bzip2=${bzip2.dev}"
+    "--with-xml2-config=${libxml2.dev}/bin/xml2-config"
+  ];
+
+  # Fix for newer OpenSSL and GCC - allow deprecated API calls and implicit declarations
+  env = {
+    NIX_CFLAGS_COMPILE = toString [
+      "-Wno-error=deprecated-declarations"
+      "-Wno-error=implicit-function-declaration"
+      "-Wno-error=builtin-declaration-mismatch"
+      "-I${openssl.dev}/include"
+    ];
+    NIX_LDFLAGS = "-L${openssl.out}/lib -lcrypto -lssl";
+  };
+
+  # Make warnings non-fatal
+  makeFlags = ["CFLAGS=-Wno-error"];
+
+  meta = with lib; {
+    description = "Extensible Archiver (osxcross fork)";
+    homepage = "https://github.com/tpoechtrager/xar";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = [];
+  };
+}


### PR DESCRIPTION
## Summary

This PR adds a comprehensive Nix flake that enables building the OSXCross macOS cross-compilation toolchain in a reproducible, declarative way. The flake provides first-class integration with the Nix ecosystem including Rust cross-compilation helpers for use with rust-overlay and crane.

Alternatively, I can also maintain the flake downstream if you don't want to support `nix`.

## Features

### Core Toolchain
- **Complete toolchain build** - Builds cctools-port, ld64, TAPI library, XAR, and compiler wrappers
- **SDK auto-detection** - Automatically detects SDK version from tarball filename
- **Multi-architecture support** - arm64, arm64e, x86_64, x86_64h, i386 (SDK-dependent)
- **Configurable options** - Deployment target, architecture selection, LTO support

### Rust Integration
- **rust-overlay compatible** - Helpers for setting up Rust cross-compilation
- **crane integration** - `mkCrossBuilder` wraps crane for easy cross-builds
- **Universal binary support** - `mkUniversalBinary` creates fat binaries from arm64 + x86_64 builds
- **Environment helpers** - `cargoEnvFor`, `mkCargoConfig`, `mkDevShellHook`

### Build Quality
- **Minimal shell scripting** - Logic implemented in native Nix where possible
- **Pure data structures** - Symlink definitions as attrsets, not shell commands
- **No pkg-config shadowing** - Unprefixed pkg-config intentionally omitted to avoid breaking native Linux builds

## Usage

```nix
{
  inputs.osxcross.url = "github:tpoechtrager/osxcross";

  outputs = { osxcross, ... }: {
    packages.x86_64-linux.myApp = let
      toolchain = osxcross.lib.x86_64-linux.mkOsxcross {
        sdkPath = ./MacOSX14.5.sdk.tar.xz;
      };
    in /* use toolchain */;
  };
}
```

## Files Added

| File | Description |
|------|-------------|
| `flake.nix` | Main flake with `mkOsxcross`, `mkRustHelpers`, overlay |
| `nix/lib.nix` | SDK version mapping, architecture validation, symlink generation |
| `nix/osxcross.nix` | Main derivation combining all components |
| `nix/cctools-port.nix` | Apple cctools and ld64 linker |
| `nix/wrapper.nix` | Compiler wrapper build |
| `nix/sdk.nix` | SDK extraction from tarballs |
| `nix/xar.nix` | XAR archive tool |
| `nix/apple-libtapi.nix` | Apple TAPI library for .tbd files |
| `nix/rust.nix` | Rust cross-compilation helpers |
| `nix/README.md` | Comprehensive documentation |

## Testing

```bash
# Check flake evaluation
nix flake check --no-build

# Build standalone packages
nix build .#xar
nix build .#apple-libtapi

# Build full toolchain (requires SDK)
nix build --impure --expr '
  (builtins.getFlake (toString ./.)).lib.x86_64-linux.mkOsxcross {
    sdkPath = /path/to/MacOSX14.5.sdk.tar.xz;
  }
'
```

## Commit signature verification

Will sign the commit later.